### PR TITLE
feat: add validated team recipes and operating playbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Hermes Profile Packs will be documented here.
 
 ### Added
 
+- Added a validated `recipes.json` team-composition layer with minimal, recommended, and expanded tiers across Agency, Council, and Academy.
+- Added `recipes.py` for deterministic recipe discovery, recommendation, dry-run planning, JSON output, and explicit `--yes` installation through the existing profile installer.
+- Added first-team onboarding, team operating guidance, post-install verification, troubleshooting, and sanitized worked examples.
+- Added `coordination-pattern-selection` to Agency Orchestrator and strengthened its SOUL to prefer the smallest capable team instead of delegation-by-default.
+- Added recipe schema validation and root recipe tests for tier monotonicity, profile resolution, recommendation behavior, and JSON dry-run plans.
+- Added the detailed Team Operating Layer implementation/acceptance plan and documented the source/runtime boundary for recipes and optional routines.
 - Added an interactive root installer wizard that recommends a small profile set from plain-language goals, supports pack/category browsing and direct search, previews the exact install plan, and still offers an explicit install-everything path.
 - Added a deterministic agent/script interface with JSON catalog and recommendation output, exact profile/category selection, pack filtering, dry-run planning, and non-interactive `--yes` installation.
 - Added profile-selection payload estimates so sparse installs show how much of the catalog they avoid installing.

--- a/PACK_SPEC.md
+++ b/PACK_SPEC.md
@@ -42,6 +42,34 @@ Pack manifests are the authoritative roster. A roster entry includes:
 
 The manifest is designed for discovery and routing; `SOUL.md` remains the behavioral contract.
 
+## Team recipes
+
+`recipes.json` is the authoritative registry for portable team compositions.
+
+A recipe is not a new runtime primitive. It references existing released profile identities and describes a useful formation for a common outcome.
+
+Every recipe must contain:
+
+- stable lowercase kebab-case `id`;
+- `display_name`;
+- one owning `pack` (`agency`, `council`, or `academy`);
+- `description` and `when_to_use`;
+- non-empty search `keywords`;
+- `minimal`, `recommended`, and `expanded` tiers;
+- a non-empty `workflow`;
+- non-empty observable `success_criteria`;
+- optional runtime routine suggestions.
+
+Tier rules:
+
+- every profile reference must exist in the owning pack;
+- no cross-pack profile references are allowed inside a single recipe;
+- `minimal` must be a subset of `recommended`;
+- `recommended` must be a subset of `expanded`;
+- larger tiers should add distinct expertise, independent review, or useful parallelism rather than status or duplication.
+
+Recipe installation must reuse the normal Profile Packs/Hermes distribution path. Recipes may suggest runtime routines, but must never create cron jobs, memory, sessions, groups, Kanban state, credentials, or other live state during installation.
+
 ## Separation of concerns
 
 Profiles should own a bounded domain. When a request materially belongs elsewhere, complete the part owned by the current profile and hand off the rest with sufficient context.
@@ -55,5 +83,5 @@ Academy profiles have an additional teaching rule: adapt instruction to the lear
 Profile and pack versions use semantic versioning.
 
 - Patch: wording, examples, or compatible skill improvements.
-- Minor: new profiles, skills, or backward-compatible metadata.
-- Major: renamed/removed profiles, incompatible distribution behavior, or semantic contract changes.
+- Minor: new profiles, skills, recipes, or backward-compatible metadata.
+- Major: renamed/removed profiles or recipes, incompatible distribution behavior, or semantic contract changes.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,22 @@ This repository is the public upstream home for reusable Hermes profile distribu
 
 The packs deliberately separate durable context domains. Agency executes professional work, Council supports the person, and Academy teaches. A work profile should not need private life context, a personal profile should not inherit repository state merely because both run on Hermes, and a teaching profile should not silently become a production executor.
 
-Hermes Council currently contains 21 focused profiles and 84 purpose-built personal-life skills. Hermes Academy v0.2 contains 30 faculty profiles and 120 purpose-built teaching skills.
+Hermes Council currently contains 21 focused profiles and 84 purpose-built personal-life skills. Hermes Academy v0.2 contains 30 faculty profiles and 120 purpose-built teaching skills. Hermes Agency contains 109 professional specialists.
+
+## Start small with Team Recipes
+
+You rarely need all 160 profiles. Team Recipes are validated compositions of existing profiles for common outcomes, with `minimal`, `recommended`, and `expanded` tiers.
+
+```bash
+python recipes.py --list
+python recipes.py --recommend "build and ship a web app"
+python recipes.py software-delivery --tier minimal --dry-run
+python recipes.py software-delivery --tier recommended --yes
+```
+
+Recipes are portable selection guidance only. They do not create memory, cron jobs, Bot groups, Kanban state, credentials, or other runtime state. Installation still uses the normal Profile Packs/Hermes distribution path.
+
+See [`docs/TEAM_RECIPES.md`](docs/TEAM_RECIPES.md) and [`docs/FIRST_TEAM.md`](docs/FIRST_TEAM.md).
 
 ## Repository layout
 
@@ -29,10 +44,13 @@ hermes-profile-packs/
 ├── hermes-academy/         # Education profile pack
 │   ├── academy.json
 │   └── profiles/
-├── docs/
-├── tests/                  # Root installer/selector tests
+├── docs/                   # Architecture, installer, recipes, onboarding, operating guidance
+├── examples/               # Sanitized worked team examples
+├── tests/                  # Root installer/recipe tests
 ├── packs.json
-├── install.py              # Human wizard + agent-friendly selector
+├── recipes.json            # Validated team composition registry
+├── install.py              # Human wizard + agent-friendly profile selector
+├── recipes.py              # Deterministic team recipe selector/installer
 └── validate.py
 ```
 
@@ -50,9 +68,9 @@ profiles/<namespace-name>/
 
 Runtime state is never distributed. Authentication material, `.env` files, logs, caches, databases, local paths, session history, and machine-specific configuration do not belong in this repository.
 
-## Install
+## Install individual profiles
 
-For most people, just launch the selector:
+For most people, launch the selector:
 
 ```bash
 python install.py
@@ -86,6 +104,12 @@ python install.py --all --yes --json
 
 See [`docs/INSTALLER.md`](docs/INSTALLER.md) for the full wizard and agent contract.
 
+## Operate the team
+
+Once profiles are installed, use [`docs/OPERATING_PLAYBOOK.md`](docs/OPERATING_PLAYBOOK.md) for solo/pair/team selection, durable handoffs, the "chat deliberates; durable systems commit" rule, and optional routine guidance.
+
+Use [`docs/INSTALLATION_VERIFICATION.md`](docs/INSTALLATION_VERIFICATION.md) to verify a real install and [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) when adoption goes sideways.
+
 ## Validate
 
 Run the full repository validation suite before publishing changes:
@@ -95,7 +119,7 @@ python validate.py
 python -m unittest discover -s tests -p 'test_*.py'
 ```
 
-This validates all registered pack manifests, profile namespaces, distribution metadata, required profile files, skill frontmatter, portability, common secret/path leaks, and the root installer/selector behavior. Pack-specific validators and tests enforce additional contracts.
+This validates all registered pack manifests, profile namespaces, distribution metadata, required profile files, skill frontmatter, portability, common secret/path leaks, team recipe references/tier invariants, and root selector behavior. Pack-specific validators and tests enforce additional contracts.
 
 ## Design principles
 
@@ -103,9 +127,10 @@ This validates all registered pack manifests, profile namespaces, distribution m
 2. **Namespace isolation.** `agency-*` is professional, `council-*` is personal, and `academy-*` is educational.
 3. **Portable distributions only.** No runtime state, secrets, personal filesystem paths, or local caches.
 4. **Specialists remain specialists.** Profiles should hand off rather than silently absorbing unrelated domains.
-5. **Human agency stays central.** Council profiles support decisions and capability; they do not attempt to run a person's life.
-6. **Safety beats role-play.** Profiles do not manufacture medical, legal, financial, spiritual, parental, credentialing, or other authority they do not possess.
-7. **Academy teaches for transfer.** Explanations, examples, practice, feedback, and mastery checks should make the learner progressively more capable rather than merely dependent on answers.
+5. **Smallest useful team.** Recipes and orchestrators should add profiles only for distinct expertise, independent review, or useful parallelism.
+6. **Human agency stays central.** Council profiles support decisions and capability; they do not attempt to run a person's life.
+7. **Safety beats role-play.** Profiles do not manufacture medical, legal, financial, spiritual, parental, credentialing, or other authority they do not possess.
+8. **Academy teaches for transfer.** Explanations, examples, practice, feedback, and mastery checks should make the learner progressively more capable rather than merely dependent on answers.
 
 See [`PACK_SPEC.md`](PACK_SPEC.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), and [`SECURITY.md`](SECURITY.md) for repository standards.
 

--- a/docs/FIRST_TEAM.md
+++ b/docs/FIRST_TEAM.md
@@ -1,0 +1,82 @@
+# Your First Useful Team
+
+The fastest way to understand Profile Packs is not to install all 160 profiles. Start with one real outcome, choose the smallest useful recipe, prove the profiles work, then expand only when another specialty earns its seat.
+
+## 1. Pick an outcome
+
+Examples:
+
+- "Build and ship a small web feature."
+- "Help me reset my routines and priorities."
+- "Teach me defensive cybersecurity."
+
+Ask the recipe selector:
+
+```bash
+python recipes.py --recommend "build and ship a web feature"
+```
+
+Then inspect the recommended recipe before installing:
+
+```bash
+python recipes.py software-delivery --tier minimal --dry-run
+```
+
+## 2. Install the smallest coherent tier
+
+```bash
+python recipes.py software-delivery --tier minimal --yes
+```
+
+Do not upgrade to `recommended` or `expanded` because the names look useful. Add roles when the work actually crosses into their specialty, when independent review is justified, or when a clean parallel seam exists.
+
+## 3. Prove one real workflow
+
+### Agency proof
+
+Give the team one bounded software outcome with checkable acceptance criteria.
+
+A healthy flow looks roughly like:
+
+Product intent -> architecture only if needed -> one implementation owner -> independent review/QA -> Git/release closure.
+
+Success means you can point to the deliverable, owner, evidence, and next state without reconstructing a long chat transcript.
+
+### Council proof
+
+Start with the minimal `personal-reset` or another relevant Council recipe. Let `council-steward` identify the smallest domains that matter. Share only the context each specialist needs.
+
+Success means you leave with a small practical plan, specialists did not absorb unrelated private context, and the user remains the decision-maker.
+
+### Academy proof
+
+Start with `cybersecurity-learning` or `technical-study`. Let `academy-dean` route to the narrowest useful faculty.
+
+Success means the learner can apply the material to a different example, not merely repeat the explanation.
+
+## 4. Verify in fresh sessions
+
+After installation, open the installed profiles through the normal Hermes profile/alias surface and verify:
+
+- the profile identifies the correct role;
+- its boundaries match the shipped SOUL;
+- relevant bundled skills are available;
+- a multi-profile recipe produces at least one clean handoff or independent review where expected.
+
+See `docs/INSTALLATION_VERIFICATION.md`.
+
+## 5. Expand only for a reason
+
+Move from minimal -> recommended -> expanded when at least one is true:
+
+- a new specialty owns a material decision;
+- independent review is worth its cost;
+- work can be split into independently verifiable packages;
+- the critical path genuinely benefits from parallelism;
+- a recurring operational need justifies another specialist.
+
+If you cannot explain what the new profile uniquely owns, do not add it yet.
+
+## What success looks like
+
+You installed a small set rather than the whole catalog, completed a real outcome, saw correct role boundaries and at least one useful handoff/review, and can name exactly why you would add the next profile.

--- a/docs/INSTALLATION_VERIFICATION.md
+++ b/docs/INSTALLATION_VERIFICATION.md
@@ -1,0 +1,65 @@
+# Installation Verification
+
+Repository CI proves that Profile Packs source distributions are valid. This checklist answers a different question: **did the profiles actually install and behave correctly in this Hermes environment?**
+
+No undocumented Hermes flags are required by this guide.
+
+## 1. Installer result
+
+The selected pack installer must finish without an error. If recipe installation is used, inspect the exact plan first:
+
+```bash
+python recipes.py software-delivery --tier minimal --dry-run
+```
+
+Then install that exact tier with `--yes`.
+
+## 2. Presence
+
+Use the normal Hermes profile or generated alias surface you already use for installed profiles. Confirm every profile named in the recipe plan is available.
+
+Do not treat a source directory in this Git checkout as proof of installation.
+
+## 3. Fresh-session identity
+
+Open a fresh session with one installed profile and ask it to state:
+
+- its role;
+- what it owns;
+- what it should hand off;
+- what completion means for its work.
+
+The answer should match the shipped SOUL contract rather than a generic assistant identity.
+
+## 4. Skill availability
+
+Give the profile a task that should naturally call for one of its bundled skills. Confirm the procedure/behavior matches that specialty.
+
+You do not need to force every skill into context. The proof is that relevant bundled capability is available when the matching task occurs.
+
+## 5. Recipe interaction proof
+
+For a multi-profile recipe, run one real handoff or independent review.
+
+Examples:
+
+- Backend Engineer -> Code Reviewer with artifact and evidence.
+- Security Engineer -> Security Reviewer/Red Team within explicit authorized scope.
+- Council Steward -> one personal specialist with minimum-necessary context.
+- Academy Dean -> the most specific faculty member for a learning objective.
+
+## 6. Source/runtime separation
+
+Verify that normal use did not write runtime state back into this repository. Profile Packs source should remain free of credentials, sessions, logs, local memory, databases, and machine-specific state.
+
+## 7. Evidence to keep
+
+For a useful smoke proof, keep only what is needed:
+
+- recipe id and tier;
+- exact installed profile list;
+- one fresh-session identity result;
+- one handoff/review or teaching transfer result;
+- any failure and its resolution.
+
+Do not commit private runtime evidence into the public source pack.

--- a/docs/OPERATING_PLAYBOOK.md
+++ b/docs/OPERATING_PLAYBOOK.md
@@ -1,0 +1,94 @@
+# Operating Playbook
+
+Profile Packs supplies specialists. Hermes supplies the runtime primitives. This playbook describes how to combine them without turning coordination into the work itself.
+
+## Choose the coordination pattern before delegating
+
+### Solo
+
+Use one specialist when one domain clearly owns the outcome and the work is coherent end to end.
+
+Examples: a Backend Engineer fixing a contained service bug; a Parenting Coach helping plan a boundary conversation; a Physics Professor teaching one mechanics concept.
+
+### Pair
+
+Add a second specialist when it brings a distinct lens, independent review, or one clean dependency.
+
+Examples: Backend Engineer + Code Reviewer; Product Manager + Product Designer; learner + Cybersecurity Instructor.
+
+### Team
+
+Use several specialists when there are three or more genuinely distinct owned work packages with clear seams, or when risk requires several independent gates.
+
+Do not create a team because the task sounds important.
+
+## Decision test
+
+Before splitting work, answer:
+
+1. What is the observable outcome?
+2. Which specialty owns the primary decision or deliverable?
+3. What distinct expertise would another profile add?
+4. Can the seam between packages be stated in one sentence?
+5. Can each package be independently validated?
+6. Does parallelism shorten the real critical path?
+7. Is independent review more useful than another implementation owner?
+8. Who synthesizes the result, and what context must cross that boundary?
+
+If the seam is unclear, prefer one coherent owner.
+
+## Chat deliberates; durable systems commit
+
+Use conversations and group rooms to explore, question, critique, and decide.
+
+When something becomes a commitment, move it into the operator's durable work system, such as Hermes Kanban:
+
+- owner;
+- expected outcome;
+- dependencies;
+- acceptance criteria;
+- important decision/evidence links;
+- completion or blocked state.
+
+A room should not become an accidental database.
+
+## Handoffs
+
+A good handoff contains:
+
+- outcome;
+- concrete artifacts;
+- evidence;
+- risks/unknowns;
+- next expected action.
+
+Do not transfer entire transcripts when a compact state packet will do.
+
+## Independent quality
+
+When correctness is why you want another profile, prefer a reviewer over a second author.
+
+Implementation and independent review should remain distinct when the consequence of error justifies it.
+
+## Optional routines
+
+Recipes include optional routine ideas, but Profile Packs never registers them automatically. The operator decides whether to create schedules in Hermes.
+
+Useful patterns include:
+
+- `agency-chief-of-staff`: review blocked/unowned work and surface decisions, not status noise;
+- `agency-security-operations-engineer`: periodic advisory or security-change review for maintained systems;
+- `agency-open-source-maintainer`: upstream/dependency and stale-maintenance review;
+- `academy-dean`: study-plan review when a learner explicitly wants recurring structure.
+
+A routine is useful when it produces a decision, artifact, alert, or meaningful state change. "I'm still here" is not a deliverable.
+
+## Pack boundaries still apply
+
+Agency executes professional work. Council supports the person. Academy teaches.
+
+Recipes do not merge those durable context domains. If a real workflow needs more than one pack, share only the minimum context required and keep each pack's authority/boundary intact.
+
+## What success looks like
+
+A small number of profiles own clear packages; chats contain useful deliberation rather than endless acknowledgement; commitments live in durable state; review is independent where needed; the final synthesis is easy to reconstruct from artifacts and evidence.

--- a/docs/TEAM_OPERATING_LAYER_PLAN.md
+++ b/docs/TEAM_OPERATING_LAYER_PLAN.md
@@ -1,0 +1,242 @@
+# Team Operating Layer Implementation Plan
+
+Status: implemented on the `feat/team-recipes-operating-layer` branch.
+
+## Purpose
+
+Hermes Profile Packs already provides the reusable people: namespaced Hermes profiles, SOUL contracts, bundled skills, manifests, installers, validators, and tests. This program adds the missing adoption and operating layer without turning the repository into a runtime framework.
+
+The new layer answers four questions:
+
+1. Which small group of profiles should I install for a common outcome?
+2. How should those profiles divide work without creating coordination overhead?
+3. What does a healthy first run look like after installation?
+4. How can an operator adopt useful routines while keeping runtime state owned by Hermes rather than by Profile Packs?
+
+## Architectural boundary
+
+Profile Packs remains a source-distribution repository.
+
+It may ship:
+
+- team recipes that reference stable profile identities;
+- operating guidance and worked examples;
+- verification checklists;
+- optional routine suggestions;
+- reusable profile skills that improve coordination judgment.
+
+It does not own or distribute:
+
+- live memory, STATE files, session history, or user vault contents;
+- cron registrations;
+- Bot/group membership;
+- Kanban boards or tasks;
+- learned local skills;
+- model credentials or provider configuration;
+- Fleet placement, transport, or node state.
+
+A recipe is advice plus a deterministic profile selection. It never grants authority and never creates runtime state by itself.
+
+## Phase 1: Recipe schema and registry
+
+Create `recipes.json` as the canonical machine-readable roster for proven team formations.
+
+Each recipe contains:
+
+- stable `id`;
+- `display_name`;
+- owning `pack`;
+- short `description` and `when_to_use` guidance;
+- search `keywords`;
+- `minimal`, `recommended`, and `expanded` profile tiers;
+- a concise workflow;
+- observable success criteria;
+- optional runtime routine suggestions.
+
+Rules:
+
+- Recipes reference existing profile identities only.
+- A recipe belongs to one durable context domain: Agency, Council, or Academy.
+- `minimal` must be a subset of `recommended`; `recommended` must be a subset of `expanded`.
+- Bigger tiers add distinct expertise, review, or useful parallelism. They are not prestige levels.
+- No recipe installs every profile by default.
+- Optional routines are documentation only and are never registered automatically.
+
+Initial catalog covers software delivery, API/backend work, security review, open-source maintenance, product launches, game development, research/analysis, personal reset, family support, fitness/recovery, technical study, and cybersecurity learning.
+
+Acceptance:
+
+- Every referenced profile exists.
+- Every profile belongs to the recipe's owning pack.
+- Tier nesting is deterministic and validated.
+- Registry passes repository validation and unit tests.
+
+## Phase 2: Deterministic recipe selector
+
+Add `recipes.py` as an additive companion to the existing profile-level `install.py`.
+
+Design rule: do not create a second installer or profile catalog.
+
+`recipes.py` imports and reuses the existing root installer for:
+
+- profile catalog loading;
+- source-size accounting;
+- profile installation;
+- JSON output conventions;
+- Hermes-native pack installer delegation.
+
+Supported flows:
+
+```bash
+python recipes.py --list
+python recipes.py --recommend "build and ship a web app"
+python recipes.py software-delivery --tier minimal --dry-run
+python recipes.py software-delivery --tier recommended --dry-run --json
+python recipes.py software-delivery --tier recommended --yes
+```
+
+Safety:
+
+- Listing, recommendation, recipe inspection, and dry-run are read-only.
+- Writes require explicit `--yes`.
+- JSON mode never prompts.
+- Unknown recipes and tiers fail closed.
+- The resulting install still uses each pack's native `hermes profile install` flow through the existing root installer.
+
+Acceptance:
+
+- Recipe selection resolves exact profile names deterministically.
+- Dry-run reports exact profiles and catalog payload statistics.
+- Agent/script callers can use JSON.
+- No duplicated installation implementation exists.
+
+## Phase 3: First useful team onboarding
+
+Add `docs/FIRST_TEAM.md`.
+
+The guide deliberately avoids the "install everything" trap. It provides one short proof path for each pack:
+
+- Agency: install a small delivery team, complete one bounded multi-profile workflow, and capture one independent review.
+- Council: install Steward plus the smallest relevant personal-support set, preserve minimum-necessary context, and complete one practical plan.
+- Academy: install Dean plus relevant faculty, complete one lesson/practice loop, and verify transfer rather than mere explanation.
+
+Acceptance:
+
+- A newcomer can reach a useful result without understanding the full 160-profile catalog.
+- The guide uses existing Hermes/Profile Packs primitives only.
+
+## Phase 4: Operating playbook
+
+Add `docs/OPERATING_PLAYBOOK.md` with shared rules that apply after installation.
+
+Core decision model:
+
+1. Prefer one clear owner when one specialty can complete the work coherently.
+2. Add a second specialist only for distinct expertise, independent review, or a clean parallel seam.
+3. Use larger teams only when work packages can be independently owned and verified.
+4. If the seam cannot be stated clearly, do not split the work merely to create activity.
+5. Prefer independent review over multiple implementers when correctness is the main reason for adding another profile.
+
+Durability rule:
+
+- Chat/group rooms deliberate.
+- Kanban or another operator-selected durable work system records commitments, ownership, dependencies, decisions, and completion evidence.
+
+Acceptance:
+
+- The guidance reduces unnecessary delegation rather than encouraging swarm-by-default behavior.
+- It preserves the existing Agency handoff/evidence contract.
+
+## Phase 5: Orchestrator coordination judgment
+
+Add a new Agency Orchestrator skill, `coordination-pattern-selection`.
+
+The skill makes the Orchestrator explicitly decide among:
+
+- solo ownership;
+- paired execution/review;
+- multi-specialist decomposition.
+
+It evaluates domain count, ownership clarity, dependency seams, review needs, critical-path benefit, context-transfer cost, and synthesis risk before decomposing work.
+
+Update the Orchestrator SOUL so delegation is not treated as success by itself.
+
+Acceptance:
+
+- Simple single-domain work stays with one specialist.
+- Independent review is selected when review is the actual need.
+- Multi-profile work has explicit seams and owners.
+
+## Phase 6: Runtime verification guidance
+
+Add `docs/INSTALLATION_VERIFICATION.md`.
+
+The checklist distinguishes repository validation from user-install verification.
+
+Repository validation proves the source distribution is internally valid.
+Runtime verification asks the operator to prove that an installed profile actually behaves as intended in a fresh Hermes session.
+
+Checks include:
+
+- installation completed without pack-installer failure;
+- expected aliases/profiles are present through the normal Hermes surface;
+- the profile identifies the correct role and boundaries in a fresh session;
+- bundled skills are available when relevant;
+- one handoff or review works when the recipe requires multiple profiles;
+- no source repository files are used as runtime state.
+
+No undocumented Hermes CLI flags are invented merely to automate this.
+
+## Phase 7: Worked examples
+
+Add sanitized examples showing the lifecycle rather than fake transcripts:
+
+- software delivery;
+- security review;
+- Council personal reset;
+- Academy technical study.
+
+Each example shows:
+
+user outcome -> recipe/tier -> ownership -> durable task split -> handoffs/review -> observable success.
+
+Examples contain no runtime credentials, user memory, or machine-specific paths.
+
+## Phase 8: Troubleshooting and routines
+
+Add `docs/TROUBLESHOOTING.md` for common adoption failures and include optional routine patterns in the operating documentation.
+
+Routine principles:
+
+- Profile Packs may suggest a routine and its intended owner.
+- The user explicitly creates runtime schedules in Hermes if desired.
+- Profile Packs never registers cron jobs during profile/recipe installation.
+- Routines must produce useful artifacts or decisions, not status noise.
+
+Examples include Chief of Staff board review, Security Operations advisory review, Open Source Maintainer upstream review, and Academy study-plan review.
+
+## Phase 9: Validation, CI, and release gate
+
+Extend `validate.py` to validate `recipes.json`.
+
+Add root unit tests for:
+
+- recipe loading;
+- tier monotonicity;
+- profile resolution;
+- deterministic recommendations;
+- JSON dry-run planning.
+
+Existing GitHub Actions already runs `python validate.py` and root unit tests, so the new layer enters the normal repository gate automatically.
+
+Release acceptance:
+
+```bash
+python validate.py
+python -m unittest discover -s tests -p 'test_*.py'
+python -m unittest discover -s hermes-agency/tests -p 'test_*.py'
+python -m unittest discover -s hermes-council/tests -p 'test_*.py'
+python -m unittest discover -s hermes-academy/tests -p 'test_*.py'
+```
+
+The branch must pass CI before merge.

--- a/docs/TEAM_RECIPES.md
+++ b/docs/TEAM_RECIPES.md
@@ -1,0 +1,74 @@
+# Team Recipes
+
+Team recipes are validated, portable compositions of existing Hermes Profile Packs profiles. They answer a practical question: **which small set should I install for this kind of outcome?**
+
+A recipe does not create a new agent type, scheduler, room, board, memory store, or runtime. It resolves stable profile identities and delegates installation to the existing Profile Packs installer.
+
+## Browse and recommend
+
+```bash
+python recipes.py --list
+python recipes.py --list --json
+python recipes.py --recommend "build and ship a web app"
+python recipes.py --recommend "learn cybersecurity" --json
+```
+
+## Tiers
+
+Every recipe has three nested tiers:
+
+- **minimal**: the smallest coherent set that can perform the core workflow;
+- **recommended**: the default balance of expertise, review, and coordination;
+- **expanded**: additional distinct specialties for larger or higher-risk work.
+
+Bigger is not automatically better. Use the smallest tier that adds real expertise or independent verification.
+
+## Inspect before installing
+
+```bash
+python recipes.py software-delivery --tier minimal
+python recipes.py software-delivery --tier recommended --dry-run
+python recipes.py security-review --tier recommended --dry-run --json
+```
+
+Without `--yes`, recipe selection is read-only. The plan shows exact profile names, source-payload estimates, workflow guidance, success criteria, and optional runtime ideas.
+
+## Install
+
+```bash
+python recipes.py software-delivery --tier recommended --yes
+python recipes.py api-backend --tier minimal --yes
+python recipes.py personal-reset --tier minimal --yes
+python recipes.py cybersecurity-learning --tier recommended --yes
+```
+
+Installation reuses the root installer and each pack's normal `hermes profile install` path. Recipe tooling does not maintain a second profile catalog.
+
+## Initial catalog
+
+### Hermes Agency
+
+- `software-delivery` — cross-functional software planning, implementation, review, QA, source control, and release.
+- `api-backend` — APIs, services, persistence, security, performance, and backend quality.
+- `security-review` — security review, threat modeling, privacy/compliance, QA, and authorized adversarial testing.
+- `open-source-maintenance` — repository maintenance, review, QA, release hygiene, docs, and community-facing work.
+- `product-launch` — product intent, launch sequencing, positioning, content, channels, analytics, and customer follow-through.
+- `game-development` — game design, Godot implementation, levels/worlds, creative production, QA, and release.
+- `research-analysis` — research, market/competitive evidence, data/business analysis, and decision-ready synthesis.
+
+### Hermes Council
+
+- `personal-reset` — clarity, resilience, attention, routines, and practical stabilization.
+- `family-support` — parenting, communication, relationships, and household systems with privacy-aware routing.
+- `fitness-recovery` — training, nutrition, sleep, recovery, and health-care navigation boundaries.
+
+### Hermes Academy
+
+- `technical-study` — computer science, systems, quantitative foundations, research methods, and adjacent faculty.
+- `cybersecurity-learning` — defensive cybersecurity with prerequisite-aware computer science and systems teaching.
+
+## Runtime boundary
+
+Recipes may suggest useful routines, but never register them. They do not distribute memory, sessions, learned skills, group membership, Kanban state, credentials, or machine-specific configuration.
+
+See `docs/OPERATING_PLAYBOOK.md` for how to run a selected team and `docs/INSTALLATION_VERIFICATION.md` for post-install checks.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,74 @@
+# Troubleshooting
+
+## `recipes.py` says a recipe is unknown
+
+Run:
+
+```bash
+python recipes.py --list
+```
+
+Recipe IDs are stable lowercase kebab-case names such as `software-delivery` and `personal-reset`.
+
+## A recipe recommendation is not what I want
+
+Recommendations are local deterministic matching, not an LLM judgment. Rephrase the outcome with concrete domain words, inspect several candidates, or choose a recipe directly.
+
+The recommendation is advice. You remain the selector.
+
+## The recipe seems too large
+
+Use `--tier minimal` and inspect the plan. Expanded tiers are not better by default.
+
+```bash
+python recipes.py software-delivery --tier minimal --dry-run
+```
+
+## The recipe is missing a specialist I need
+
+First confirm that the specialist owns a genuinely distinct decision, review, or work package. You can install an additional profile through the existing root installer without changing the recipe.
+
+A recurring gap across many real uses is evidence for proposing a recipe change.
+
+## Installation fails because Hermes is unavailable
+
+Pack installation requires the `hermes` executable on `PATH`. The repository cannot repair a missing Hermes installation or provider configuration. Fix the Hermes environment, then re-run the same dry-run/installation selection.
+
+## A profile installed but behaves generically
+
+Open a fresh session and verify you are actually using the intended installed profile/alias. Compare its role and boundaries with the source `SOUL.md`. If the wrong identity loads, treat that as a Hermes/profile-selection problem rather than rewriting the SOUL to mask it.
+
+## A bundled skill appears missing
+
+Confirm the profile distribution itself contains the expected `skills/<name>/SKILL.md` and that installation completed successfully. Do not copy live runtime skill state back into the repository as a workaround.
+
+## Too many agents are talking
+
+Reduce the coordination pattern. Route the outcome to one owner, add a reviewer only if needed, and use a larger team only when work has clean independently verifiable seams.
+
+See `docs/OPERATING_PLAYBOOK.md`.
+
+## The group chat made a decision but nobody owns it
+
+Conversation is not the durable commitment layer. Create/update the corresponding Kanban task or other operator-selected system of record with owner, outcome, dependencies, and acceptance criteria.
+
+## I want recurring team routines
+
+Recipes may suggest routines, but installation never creates cron jobs automatically. Configure a Hermes routine explicitly only after deciding its owner, useful output, cadence, and escalation behavior.
+
+## My local profile learned something. Should I commit it here?
+
+Not automatically. Local memory and learned skills belong to the installed profile. Public Profile Packs source remains deterministic. Upstreaming a learned procedure is a separate human-reviewed contribution.
+
+## Validation fails on `recipes.json`
+
+The validator enforces:
+
+- valid unique recipe IDs;
+- known owning pack;
+- existing profile references;
+- no cross-pack references inside a recipe;
+- non-empty workflow/success criteria;
+- minimal subset of recommended subset of expanded.
+
+Fix the recipe data rather than weakening validation.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,12 @@
+# Worked Examples
+
+These examples show how Profile Packs compositions are intended to operate. They are lifecycle examples, not fake transcripts and not runtime state.
+
+- `software-delivery.md` — one bounded software feature from product intent through review and release closure.
+- `security-review.md` — independent security assessment with explicit scope and remediation ownership.
+- `council-personal-reset.md` — privacy-aware personal support with a small Council.
+- `academy-technical-study.md` — learner routing, instruction, practice, and transfer.
+
+Each example follows the same shape:
+
+outcome -> recipe/tier -> ownership -> durable packages -> handoffs/review -> observable success.

--- a/examples/academy-technical-study.md
+++ b/examples/academy-technical-study.md
@@ -1,0 +1,28 @@
+# Worked Example: Academy Technical Study
+
+## Outcome
+
+A learner wants to understand secure web authentication well enough to review a new design.
+
+## Composition
+
+```bash
+python recipes.py cybersecurity-learning --tier recommended --dry-run
+```
+
+## Ownership
+
+Academy Dean scopes the learning objective and routes faculty. Cybersecurity Instructor owns security teaching and transfer checks. Computer Science Professor fills foundational gaps. Cloud & Systems Instructor joins when deployment/system boundaries matter.
+
+## Learning flow
+
+1. Establish baseline understanding.
+2. Teach missing concepts and model reasoning.
+3. Give a practice case.
+4. Correct specific misconceptions.
+5. Give a meaningfully different transfer case.
+6. Call the objective complete only when the learner can generalize.
+
+## Success
+
+The learner can identify authentication/authorization trust boundaries in a novel design and explain why. Faculty taught the skill rather than doing production engineering in the learner's place.

--- a/examples/council-personal-reset.md
+++ b/examples/council-personal-reset.md
@@ -1,0 +1,27 @@
+# Worked Example: Council Personal Reset
+
+## Outcome
+
+The user feels overloaded and wants a realistic seven-day reset, not a total-life redesign.
+
+## Composition
+
+```bash
+python recipes.py personal-reset --tier minimal --dry-run
+```
+
+## Ownership
+
+Council Steward identifies which domains actually matter and shares only minimum-necessary context. Life Coach helps clarify priorities/boundaries. Resilience Coach handles non-clinical regulation/recovery. Time & Attention Coach turns chosen priorities into usable time.
+
+## Flow
+
+1. Define what "better in seven days" would look like.
+2. Identify two or three actual pressure points.
+3. Route only those pressure points.
+4. Produce a small plan with explicit tradeoffs.
+5. Return decisions to the user.
+
+## Success
+
+The plan is small enough to execute, private context stayed bounded, no profile impersonated clinical/professional authority, and the user can explain the next few actions without depending on the agents to remember the conversation for them.

--- a/examples/security-review.md
+++ b/examples/security-review.md
@@ -1,0 +1,27 @@
+# Worked Example: Security Review
+
+## Outcome
+
+Assess a new authentication flow before release and produce actionable, verified findings.
+
+## Composition
+
+```bash
+python recipes.py security-review --tier recommended --dry-run
+```
+
+## Ownership
+
+Security Reviewer owns scope and review evidence. Security Engineer owns threat/design reasoning. Privacy/Compliance specialists own their respective concerns. Code Reviewer and QA provide independent correctness evidence. Red Team acts only inside explicit authorization and scope.
+
+## Durable packages
+
+1. Scope and assets under review.
+2. Threat model and trust boundaries.
+3. Implementation findings with reproduction/evidence.
+4. Remediation tasks with owners.
+5. Verification after fixes.
+
+## Success
+
+No finding exists only as "the model thinks." Material findings have evidence and severity rationale; remediation has an owner; accepted fixes receive independent verification; authorization boundaries remain explicit.

--- a/examples/software-delivery.md
+++ b/examples/software-delivery.md
@@ -1,0 +1,38 @@
+# Worked Example: Software Delivery
+
+## Outcome
+
+Add a small authenticated API feature with a usable UI and release it safely.
+
+## Composition
+
+Start with:
+
+```bash
+python recipes.py software-delivery --tier minimal --dry-run
+```
+
+## Ownership
+
+- Product Manager: behavior and acceptance criteria.
+- Software Architect: only material system/interface boundaries.
+- Full-Stack Engineer: primary implementation owner.
+- Code Reviewer: independent implementation review.
+- QA Tester: end-to-end behavior/regression evidence.
+- Git Steward: branch/commit/PR integration state.
+
+## Durable work
+
+Create separate tasks only where ownership is distinct. Keep implementation coherent under one owner unless the API/UI seam can genuinely be split and independently validated.
+
+## Handoffs
+
+Implementation -> Code Reviewer: artifact, commands/tests run, assumptions, known risks.
+
+Implementation/review -> QA: expected user behavior, setup, edge cases, build under test.
+
+QA/review -> Git Steward: exact accepted revision and remaining blockers.
+
+## Success
+
+The feature satisfies explicit acceptance criteria; review and QA are independent; source-control state is clear; the final result can be understood without replaying the conversation history.

--- a/hermes-agency/profiles/agency-orchestrator/SOUL.md
+++ b/hermes-agency/profiles/agency-orchestrator/SOUL.md
@@ -2,17 +2,20 @@
 
 ## Role
 
-You are the **Agency Orchestrator** in Hermes Agency. Coordinates multi-specialist work by decomposing goals, routing assignments, managing dependencies, and synthesizing validated results.
+You are the **Agency Orchestrator** in Hermes Agency. Coordinates multi-specialist work by choosing the smallest useful coordination pattern, decomposing goals when clean ownership seams exist, routing assignments, managing dependencies, and synthesizing validated results.
 
 ## Responsibilities
 
-- Decompose complex goals into bounded outcomes with clear owners and dependencies.
+- Decide whether work should stay with one specialist, use a paired execution/review pattern, or require a larger multi-specialist team.
+- Decompose complex goals into bounded outcomes only where responsibilities and validation seams are clear.
 - Route each task to the most appropriate installed Agency profile using role descriptions and task context.
 - Track blockers, coordinate handoffs, request independent validation, and synthesize the final result.
 
 ## Working standard
 
 - Read the assignment, relevant artifacts, and established decisions before acting.
+- Treat delegation as a cost that must buy distinct expertise, independent review, or useful parallelism; more agents is not itself success.
+- Prefer one coherent owner when one specialty can complete the work safely and well.
 - Exercise professional judgment within this specialty instead of defaulting every decision upward.
 - State material assumptions and distinguish verified facts from inference.
 - Produce concrete work, evidence, or decisions rather than activity logs.
@@ -32,10 +35,12 @@ Typical collaborators:
 
 A handoff should state the outcome, relevant artifacts, evidence, remaining risks or unknowns, and the next action expected from the receiving profile.
 
+Chat and group rooms are for deliberation. When a decision becomes a commitment, put ownership, dependencies, acceptance criteria, and completion evidence into the normal durable work system rather than relying on conversation history alone.
+
 ## Communication
 
 Be concise, specific, and professional. Lead with the result, decision, or finding. Include exact filenames, commands, measurements, requirements, versions, or sources when they materially affect the work.
 
 ## Definition of done
 
-The assignment is complete when the requested outcome within this role's authority is delivered, validated, material risks are explicit, and any required handoff gives the next owner enough context to continue cleanly.
+The assignment is complete when the smallest capable team was used, each required outcome has a clear owner, the requested result is delivered and validated, material risks are explicit, and any required handoff gives the next owner enough context to continue cleanly.

--- a/hermes-agency/profiles/agency-orchestrator/skills/coordination-pattern-selection/SKILL.md
+++ b/hermes-agency/profiles/agency-orchestrator/skills/coordination-pattern-selection/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: coordination-pattern-selection
+description: Decide whether a goal should stay with one specialist, use a paired execution/review pattern, or be decomposed across a larger team before creating coordination overhead.
+---
+# Coordination Pattern Selection
+
+Use this before decomposing a goal merely because several profiles are available.
+
+## Procedure
+
+1. Restate the observable outcome and identify the specialty that owns the primary decision or deliverable.
+2. Count the genuinely distinct domains involved. Do not count different file types or task steps as separate specialties unless they require different professional judgment.
+3. Choose **solo ownership** when one specialist can complete the work coherently and validate it appropriately.
+4. Choose a **pair** when another specialist adds one distinct dependency, materially different expertise, or independent review. If correctness is the reason for adding someone, prefer a reviewer over a second author.
+5. Choose a **multi-specialist team** only when there are several clean work packages that can be independently owned and validated, or several independent gates are justified by risk.
+6. For every proposed split, state the seam in one sentence: what the upstream package produces and what the downstream/parallel owner consumes.
+7. Reject a split when ownership overlaps, the seam is unclear, context-transfer cost dominates, or synthesis would recreate the original task in one place anyway.
+8. Parallelize only work that does not depend on unfinished outputs from another package and whose parallel execution can shorten the real critical path.
+9. Define one synthesis owner. Synthesis reconciles specialist outputs; it does not erase disagreement, uncertainty, or failed validation.
+10. Record durable commitments in the normal work system. Use chat/group rooms for deliberation, not as the sole system of record.
+
+## Pattern guide
+
+- **Solo**: one domain, coherent implementation, low coordination value.
+- **Pair**: implementation + review, two clean domains, or one expert second opinion.
+- **Team**: several distinct packages with explicit dependencies, or high-risk work requiring multiple independent gates.
+
+## Quality gate
+
+The coordination pattern is ready when every added profile has a unique reason to participate, each work package has one owner and checkable output, dependencies are explicit, and removing any participant would remove real expertise, review, or useful parallelism rather than merely reducing activity.

--- a/recipes.json
+++ b/recipes.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": 1,
+  "tiers": ["minimal", "recommended", "expanded"],
+  "recipes": [
+    {
+      "id": "software-delivery",
+      "display_name": "Software Delivery Team",
+      "pack": "agency",
+      "description": "A compact cross-functional team for planning, building, reviewing, testing, and shipping production software.",
+      "when_to_use": "Use when the outcome is a real software feature or product slice that needs implementation plus independent quality and source-control closure.",
+      "keywords": ["software", "web", "app", "feature", "build", "ship", "release", "product"],
+      "tiers": {
+        "minimal": ["agency-product-manager", "agency-software-architect", "agency-fullstack-engineer", "agency-code-reviewer", "agency-qa-tester", "agency-git-steward"],
+        "recommended": ["agency-product-manager", "agency-software-architect", "agency-technical-lead", "agency-fullstack-engineer", "agency-code-reviewer", "agency-qa-tester", "agency-security-reviewer", "agency-git-steward", "agency-release-manager"],
+        "expanded": ["agency-product-manager", "agency-product-designer", "agency-software-architect", "agency-technical-lead", "agency-fullstack-engineer", "agency-devops-engineer", "agency-site-reliability-engineer", "agency-code-reviewer", "agency-qa-tester", "agency-security-reviewer", "agency-git-steward", "agency-release-manager"]
+      },
+      "workflow": ["Product Manager freezes outcome and acceptance criteria.", "Architect and Technical Lead establish boundaries only when architecture work is material.", "One implementation owner builds the feature; avoid parallel authorship without clean seams.", "Code Review and QA independently verify the result.", "Security review is added when risk justifies it.", "Git Steward and Release Manager close integration and release evidence."],
+      "success_criteria": ["Every deliverable has one owner.", "Implementation and independent review are distinct when risk warrants it.", "Tests or equivalent evidence demonstrate the requested behavior.", "Source-control and release state are explicit."],
+      "optional_routines": ["Chief of Staff or Project Manager board review for long-running work", "Release readiness review before production rollout"]
+    },
+    {
+      "id": "api-backend",
+      "display_name": "API & Backend Team",
+      "pack": "agency",
+      "description": "A backend-focused team for APIs, services, persistence, authentication, performance, and integration quality.",
+      "when_to_use": "Use for server-side application work where backend engineering is the primary implementation domain.",
+      "keywords": ["api", "backend", "service", "database", "auth", "integration", "server"],
+      "tiers": {
+        "minimal": ["agency-backend-engineer", "agency-database-engineer", "agency-code-reviewer", "agency-qa-tester"],
+        "recommended": ["agency-technical-lead", "agency-backend-engineer", "agency-database-engineer", "agency-security-engineer", "agency-performance-engineer", "agency-code-reviewer", "agency-qa-tester"],
+        "expanded": ["agency-technical-lead", "agency-backend-engineer", "agency-database-engineer", "agency-security-engineer", "agency-performance-engineer", "agency-integration-engineer", "agency-devops-engineer", "agency-code-reviewer", "agency-qa-tester", "agency-git-steward"]
+      },
+      "workflow": ["Backend Engineer owns service behavior and API implementation.", "Database Engineer owns material persistence design.", "Security and Performance specialists join only when those concerns are material.", "Code Reviewer and QA independently verify implementation and behavior.", "Integration/DevOps specialists handle external seams and deployment concerns when needed."],
+      "success_criteria": ["API behavior and failure semantics are explicit.", "Persistence and security boundaries are reviewed where material.", "Automated or reproducible behavioral evidence exists."],
+      "optional_routines": ["Dependency and security advisory review for maintained services"]
+    },
+    {
+      "id": "security-review",
+      "display_name": "Security Review Team",
+      "pack": "agency",
+      "description": "An independent security review formation for threat modeling, implementation review, privacy/compliance checks, and authorized adversarial testing.",
+      "when_to_use": "Use when the primary outcome is security confidence rather than feature implementation.",
+      "keywords": ["security", "threat", "audit", "review", "red team", "privacy", "compliance"],
+      "tiers": {
+        "minimal": ["agency-security-reviewer", "agency-security-engineer", "agency-code-reviewer", "agency-red-team"],
+        "recommended": ["agency-security-reviewer", "agency-security-engineer", "agency-privacy-engineer", "agency-compliance-reviewer", "agency-code-reviewer", "agency-qa-tester", "agency-red-team"],
+        "expanded": ["agency-security-reviewer", "agency-security-engineer", "agency-security-operations-engineer", "agency-privacy-engineer", "agency-compliance-reviewer", "agency-site-reliability-engineer", "agency-code-reviewer", "agency-qa-tester", "agency-red-team"]
+      },
+      "workflow": ["Security Reviewer defines review scope and evidence requirements.", "Security Engineer models threats and inspects design/implementation.", "Code Reviewer and QA provide independent correctness evidence.", "Privacy/Compliance specialists join when those domains are in scope.", "Red Team performs only authorized adversarial testing against the agreed scope."],
+      "success_criteria": ["Scope and authorization are explicit.", "Findings include evidence, severity rationale, and remediation ownership.", "Independent verification follows material fixes."],
+      "optional_routines": ["Security Operations advisory review for maintained systems"]
+    },
+    {
+      "id": "open-source-maintenance",
+      "display_name": "Open Source Maintenance Team",
+      "pack": "agency",
+      "description": "A small team for issue triage, implementation, review, release hygiene, documentation, and community-facing maintenance.",
+      "when_to_use": "Use for maintaining a public repository or upstream-facing software project.",
+      "keywords": ["open source", "repository", "github", "maintain", "issue", "pull request", "release", "upstream"],
+      "tiers": {
+        "minimal": ["agency-open-source-maintainer", "agency-code-reviewer", "agency-qa-tester", "agency-git-steward"],
+        "recommended": ["agency-open-source-maintainer", "agency-code-reviewer", "agency-qa-tester", "agency-security-reviewer", "agency-git-steward", "agency-release-manager", "agency-technical-writer"],
+        "expanded": ["agency-open-source-maintainer", "agency-code-reviewer", "agency-qa-tester", "agency-security-reviewer", "agency-git-steward", "agency-release-manager", "agency-technical-writer", "agency-developer-relations-engineer", "agency-community-manager"]
+      },
+      "workflow": ["Open Source Maintainer owns intake, scope, compatibility, and contributor context.", "Implementation is routed to the appropriate engineering owner when needed.", "Code Review and QA gate behavioral changes.", "Git Steward preserves clean history and PR state.", "Release, documentation, DevRel, and community roles join only when the work reaches those surfaces."],
+      "success_criteria": ["Issue/PR state and ownership are explicit.", "Compatibility and regression evidence exist.", "Release and public communication are updated when required."],
+      "optional_routines": ["Weekly upstream/dependency review", "Periodic stale issue and release readiness review"]
+    },
+    {
+      "id": "product-launch",
+      "display_name": "Product Launch Team",
+      "pack": "agency",
+      "description": "A launch formation for product intent, positioning, copy, channels, brand, analytics, public relations, and customer follow-through.",
+      "when_to_use": "Use when a product or major feature is ready to be introduced publicly and measured after launch.",
+      "keywords": ["launch", "marketing", "announce", "campaign", "release", "social", "brand", "growth"],
+      "tiers": {
+        "minimal": ["agency-product-manager", "agency-launch-manager", "agency-marketing-strategist", "agency-copywriter", "agency-social-media-manager", "agency-analytics-specialist"],
+        "recommended": ["agency-product-manager", "agency-launch-manager", "agency-marketing-strategist", "agency-product-marketing-manager", "agency-brand-designer", "agency-copywriter", "agency-social-media-manager", "agency-public-relations", "agency-analytics-specialist", "agency-customer-success"],
+        "expanded": ["agency-product-manager", "agency-launch-manager", "agency-marketing-strategist", "agency-product-marketing-manager", "agency-brand-designer", "agency-copywriter", "agency-social-media-manager", "agency-public-relations", "agency-email-marketer", "agency-growth-marketer", "agency-video-producer", "agency-analytics-specialist", "agency-customer-success"]
+      },
+      "workflow": ["Product Manager freezes what is launching and for whom.", "Launch Manager owns sequencing, readiness, and dependencies.", "Marketing/Product Marketing own positioning and channel strategy.", "Creative/content specialists produce channel-specific assets.", "Analytics defines measurable launch signals.", "Customer Success captures post-launch user friction."],
+      "success_criteria": ["Audience, message, channels, owner, and launch date are explicit.", "Claims are verified before publication.", "Success metrics and post-launch feedback loops are defined."],
+      "optional_routines": ["Launch readiness review", "Post-launch metrics and customer-friction review"]
+    },
+    {
+      "id": "game-development",
+      "display_name": "Game Development Team",
+      "pack": "agency",
+      "description": "A game-production formation spanning design, Godot implementation, levels, art integration, narrative/audio, QA, and release.",
+      "when_to_use": "Use for game features or vertical slices where design and implementation need several distinct creative/technical specialties.",
+      "keywords": ["game", "godot", "level", "world", "art", "narrative", "audio", "gameplay"],
+      "tiers": {
+        "minimal": ["agency-game-designer", "agency-godot-engineer", "agency-level-designer", "agency-technical-artist", "agency-qa-tester"],
+        "recommended": ["agency-game-designer", "agency-product-manager", "agency-godot-engineer", "agency-level-designer", "agency-worldbuilder", "agency-environment-artist", "agency-technical-artist", "agency-narrative-designer", "agency-audio-designer", "agency-qa-tester"],
+        "expanded": ["agency-game-designer", "agency-product-manager", "agency-godot-engineer", "agency-tools-engineer", "agency-level-designer", "agency-worldbuilder", "agency-environment-artist", "agency-asset-artist", "agency-technical-artist", "agency-ui-ux-designer", "agency-narrative-designer", "agency-audio-designer", "agency-qa-tester", "agency-release-manager"]
+      },
+      "workflow": ["Game Designer owns mechanics and player-facing intent.", "Godot Engineer owns engine implementation.", "Level/World/Art specialties receive independently bounded content packages.", "Narrative and Audio join only where the feature needs them.", "QA validates the playable result rather than reviewing documents alone."],
+      "success_criteria": ["The playable outcome and acceptance criteria are explicit.", "Creative ownership is separated from engine ownership where useful.", "The feature is tested in a real playable flow."],
+      "optional_routines": ["Milestone playtest review", "Release readiness review"]
+    },
+    {
+      "id": "research-analysis",
+      "display_name": "Research & Analysis Team",
+      "pack": "agency",
+      "description": "A research formation for evidence gathering, market/competitive analysis, quantitative interpretation, and decision-ready synthesis.",
+      "when_to_use": "Use when a decision depends on several kinds of external evidence or independent analytical lenses.",
+      "keywords": ["research", "market", "competitor", "analysis", "evidence", "data", "decision"],
+      "tiers": {
+        "minimal": ["agency-research-analyst", "agency-market-researcher", "agency-competitive-analyst"],
+        "recommended": ["agency-research-analyst", "agency-market-researcher", "agency-competitive-analyst", "agency-business-analyst", "agency-data-scientist"],
+        "expanded": ["agency-research-analyst", "agency-market-researcher", "agency-competitive-analyst", "agency-business-analyst", "agency-data-scientist", "agency-product-strategist", "agency-technical-writer"]
+      },
+      "workflow": ["Research Analyst frames evidence questions and source quality.", "Market/Competitive specialists collect domain-specific evidence independently.", "Business/Data specialists join when interpretation requires those lenses.", "Synthesis preserves disagreement, dates, confidence, and missing evidence."],
+      "success_criteria": ["Material claims are traceable to current evidence.", "Conflicting evidence and uncertainty remain visible.", "The final synthesis is decision-ready rather than a source dump."],
+      "optional_routines": ["Periodic market or competitor scan when the operator explicitly configures it"]
+    },
+    {
+      "id": "personal-reset",
+      "display_name": "Personal Reset Council",
+      "pack": "council",
+      "description": "A privacy-aware Council formation for regaining clarity, stabilizing routines, reducing overload, and choosing realistic next steps.",
+      "when_to_use": "Use when several parts of personal life feel tangled and the user wants a small, practical reset rather than a giant life overhaul.",
+      "keywords": ["reset", "overwhelmed", "life", "routine", "stress", "focus", "organize", "clarity"],
+      "tiers": {
+        "minimal": ["council-steward", "council-life-coach", "council-resilience-coach", "council-time-attention-coach"],
+        "recommended": ["council-steward", "council-life-coach", "council-resilience-coach", "council-time-attention-coach", "council-sleep-coach", "council-fitness-coach", "council-home-steward", "council-personal-admin-steward"],
+        "expanded": ["council-steward", "council-life-coach", "council-resilience-coach", "council-time-attention-coach", "council-sleep-coach", "council-fitness-coach", "council-home-steward", "council-personal-admin-steward", "council-finance-coach", "council-recreation-guide", "council-community-coach"]
+      },
+      "workflow": ["Council Steward identifies the smallest domains that actually matter.", "Each specialist receives only the personal context needed for its part.", "Life Coach helps choose priorities and boundaries.", "Resilience and Time/Attention profiles turn those priorities into sustainable near-term actions.", "Additional specialists join only for concrete needs discovered during the reset."],
+      "success_criteria": ["The user has a small number of realistic next actions.", "No specialist receives unrelated personal context by default.", "The plan leaves decisions and agency with the user."],
+      "optional_routines": ["Weekly personal review if the user explicitly wants one"]
+    },
+    {
+      "id": "family-support",
+      "display_name": "Family Support Council",
+      "pack": "council",
+      "description": "A bounded Council formation for parenting, communication, household relationships, and practical family routines.",
+      "when_to_use": "Use when a family issue spans parenting decisions, communication, and household systems.",
+      "keywords": ["family", "parenting", "kids", "children", "communication", "relationship", "household"],
+      "tiers": {
+        "minimal": ["council-steward", "council-parenting-coach", "council-communication-coach", "council-relationship-coach"],
+        "recommended": ["council-steward", "council-parenting-coach", "council-communication-coach", "council-relationship-coach", "council-home-steward", "council-resilience-coach", "council-time-attention-coach"],
+        "expanded": ["council-steward", "council-parenting-coach", "council-communication-coach", "council-relationship-coach", "council-home-steward", "council-resilience-coach", "council-time-attention-coach", "council-personal-admin-steward", "council-community-coach"]
+      },
+      "workflow": ["Steward scopes the actual family outcome and privacy boundary.", "Parenting Coach owns child-development and boundary questions.", "Communication Coach handles message/conversation practice.", "Relationship Coach handles adult relationship patterns only when relevant.", "Home/Time specialists join for routines and logistics rather than relational judgment."],
+      "success_criteria": ["Parenting, relationship, communication, and logistics ownership stay distinct.", "Advice is age-appropriate and non-humiliating.", "The user retains authority over family decisions."],
+      "optional_routines": ["Weekly household reset when the user chooses to configure one"]
+    },
+    {
+      "id": "fitness-recovery",
+      "display_name": "Fitness & Recovery Council",
+      "pack": "council",
+      "description": "A practical Council formation for training, nutrition, sleep, recovery, and health-care organization without crossing clinical boundaries.",
+      "when_to_use": "Use when the user wants a sustainable fitness system rather than a workout plan in isolation.",
+      "keywords": ["fitness", "workout", "training", "nutrition", "sleep", "recovery", "health"],
+      "tiers": {
+        "minimal": ["council-fitness-coach", "council-nutrition-coach", "council-sleep-coach", "council-health-navigator"],
+        "recommended": ["council-life-coach", "council-time-attention-coach", "council-fitness-coach", "council-nutrition-coach", "council-sleep-coach", "council-health-navigator"],
+        "expanded": ["council-life-coach", "council-resilience-coach", "council-time-attention-coach", "council-fitness-coach", "council-nutrition-coach", "council-sleep-coach", "council-health-navigator"]
+      },
+      "workflow": ["Fitness Coach owns training and adaptation.", "Nutrition Coach supports realistic fueling/eating patterns.", "Sleep Coach owns sleep-supportive routine and recovery habits.", "Health Navigator organizes symptoms, appointments, records, and professional follow-up without diagnosing.", "Life/Time/Resilience profiles join only when adherence or life constraints are the actual blocker."],
+      "success_criteria": ["Training, eating, sleep, and medical-navigation boundaries remain clear.", "The plan fits actual schedule and recovery constraints.", "Clinical concerns are escalated rather than diagnosed by the Council."],
+      "optional_routines": ["Periodic training/recovery review if explicitly configured by the user"]
+    },
+    {
+      "id": "technical-study",
+      "display_name": "Technical Study Faculty",
+      "pack": "academy",
+      "description": "A prerequisite-aware faculty set for learning computer science, systems, quantitative foundations, research methods, and adjacent technical subjects.",
+      "when_to_use": "Use for broad technical upskilling where the learner may need more than one academic foundation.",
+      "keywords": ["learn", "technical", "computer science", "systems", "engineering", "study", "programming", "cloud"],
+      "tiers": {
+        "minimal": ["academy-dean", "academy-computer-science-professor", "academy-research-methods-professor"],
+        "recommended": ["academy-dean", "academy-mathematics-professor", "academy-computer-science-professor", "academy-cloud-systems-instructor", "academy-cybersecurity-instructor", "academy-research-methods-professor"],
+        "expanded": ["academy-dean", "academy-mathematics-professor", "academy-statistics-professor", "academy-data-science-professor", "academy-computer-science-professor", "academy-engineering-professor", "academy-cloud-systems-instructor", "academy-cybersecurity-instructor", "academy-research-methods-professor"]
+      },
+      "workflow": ["Dean establishes the learning objective and routes to the narrowest faculty needed.", "Faculty teach concepts and reasoning rather than doing production work for the learner.", "Practice and feedback precede claims of mastery.", "Research Methods joins when source evaluation or study design is part of the objective.", "Additional faculty join only when prerequisites or cross-disciplinary transfer require them."],
+      "success_criteria": ["The learner can apply the material to a meaningfully different example.", "Faculty boundaries remain educational rather than production-execution roles.", "Current standards or software behavior are verified when material."],
+      "optional_routines": ["Study-plan review when the learner explicitly wants a recurring cadence"]
+    },
+    {
+      "id": "cybersecurity-learning",
+      "display_name": "Cybersecurity Learning Faculty",
+      "pack": "academy",
+      "description": "A focused Academy formation for defensive security, secure systems, computer-science foundations, and evidence-aware practice.",
+      "when_to_use": "Use when the learner wants to build durable defensive cybersecurity understanding and practical reasoning.",
+      "keywords": ["learn", "cybersecurity", "security", "threat modeling", "defensive", "auth", "networks"],
+      "tiers": {
+        "minimal": ["academy-dean", "academy-cybersecurity-instructor"],
+        "recommended": ["academy-dean", "academy-computer-science-professor", "academy-cybersecurity-instructor", "academy-cloud-systems-instructor"],
+        "expanded": ["academy-dean", "academy-mathematics-professor", "academy-computer-science-professor", "academy-cybersecurity-instructor", "academy-cloud-systems-instructor", "academy-research-methods-professor"]
+      },
+      "workflow": ["Dean scopes the learner goal and current level.", "Cybersecurity Instructor owns defensive security teaching and transfer assessment.", "Computer Science and Cloud/Systems faculty fill prerequisite gaps when needed.", "Research Methods supports evidence evaluation for security claims and standards.", "Authorized practice remains bounded and safety-aware."],
+      "success_criteria": ["The learner demonstrates the target concept on a novel defensive scenario.", "Instruction distinguishes secure-design reasoning from unauthorized offensive activity.", "The learner can explain relevant assumptions and uncertainty."],
+      "optional_routines": ["Periodic study review only when explicitly requested by the learner"]
+    }
+  ]
+}

--- a/recipes.py
+++ b/recipes.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Discover and install validated Hermes Profile Pack team recipes.
+
+Recipes are portable composition advice. They reference the existing profile catalog
+and reuse the root installer's selection/install machinery; they do not maintain a
+second profile roster or create runtime state.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import sys
+from typing import Iterable
+
+import install as profile_installer
+
+ROOT = Path(__file__).resolve().parent
+RECIPE_FILE = ROOT / "recipes.json"
+TIER_ORDER = ("minimal", "recommended", "expanded")
+
+
+class RecipeError(ValueError):
+    """User-facing recipe error."""
+
+
+@dataclass(frozen=True)
+class Recipe:
+    id: str
+    display_name: str
+    pack: str
+    description: str
+    when_to_use: str
+    keywords: tuple[str, ...]
+    tiers: dict[str, tuple[str, ...]]
+    workflow: tuple[str, ...]
+    success_criteria: tuple[str, ...]
+    optional_routines: tuple[str, ...]
+
+    def as_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "display_name": self.display_name,
+            "pack": self.pack,
+            "description": self.description,
+            "when_to_use": self.when_to_use,
+            "keywords": list(self.keywords),
+            "tiers": {tier: list(self.tiers[tier]) for tier in TIER_ORDER},
+            "workflow": list(self.workflow),
+            "success_criteria": list(self.success_criteria),
+            "optional_routines": list(self.optional_routines),
+        }
+
+    def searchable_text(self) -> str:
+        return " ".join(
+            [self.id.replace("-", " "), self.display_name, self.description, self.when_to_use, *self.keywords]
+        ).lower()
+
+
+def load_recipes(root: Path = ROOT) -> dict[str, Recipe]:
+    path = root / "recipes.json"
+    if not path.is_file():
+        raise RecipeError(f"missing recipe registry: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != 1:
+        raise RecipeError("unsupported recipes.json schema_version")
+
+    recipes: dict[str, Recipe] = {}
+    for item in payload.get("recipes", []):
+        recipe_id = str(item.get("id", ""))
+        if not recipe_id:
+            raise RecipeError("recipe is missing id")
+        if recipe_id in recipes:
+            raise RecipeError(f"duplicate recipe id: {recipe_id}")
+        raw_tiers = item.get("tiers", {})
+        tiers = {tier: tuple(str(name) for name in raw_tiers.get(tier, [])) for tier in TIER_ORDER}
+        recipes[recipe_id] = Recipe(
+            id=recipe_id,
+            display_name=str(item.get("display_name") or recipe_id),
+            pack=str(item.get("pack") or ""),
+            description=str(item.get("description") or ""),
+            when_to_use=str(item.get("when_to_use") or ""),
+            keywords=tuple(str(value) for value in item.get("keywords", [])),
+            tiers=tiers,
+            workflow=tuple(str(value) for value in item.get("workflow", [])),
+            success_criteria=tuple(str(value) for value in item.get("success_criteria", [])),
+            optional_routines=tuple(str(value) for value in item.get("optional_routines", [])),
+        )
+    return recipes
+
+
+def resolve_recipe_profiles(
+    recipe: Recipe,
+    tier: str,
+    profiles: Iterable[profile_installer.Profile],
+) -> list[profile_installer.Profile]:
+    if tier not in TIER_ORDER:
+        raise RecipeError(f"unknown tier '{tier}'. Choose: {', '.join(TIER_ORDER)}")
+    by_name = {profile.name: profile for profile in profiles}
+    selected: list[profile_installer.Profile] = []
+    for name in recipe.tiers[tier]:
+        profile = by_name.get(name)
+        if profile is None:
+            raise RecipeError(f"recipe {recipe.id} references unavailable profile: {name}")
+        if profile.pack != recipe.pack:
+            raise RecipeError(
+                f"recipe {recipe.id} belongs to {recipe.pack} but references {name} from {profile.pack}"
+            )
+        selected.append(profile)
+    return selected
+
+
+def _score(recipe: Recipe, query: str) -> tuple[int, list[str]]:
+    query_tokens = profile_installer.expanded_query(query)
+    keyword_tokens = profile_installer.tokenize(" ".join(recipe.keywords))
+    name_tokens = profile_installer.tokenize(recipe.id.replace("-", " ") + " " + recipe.display_name)
+    detail_tokens = profile_installer.tokenize(recipe.description + " " + recipe.when_to_use)
+
+    keyword_hits = sorted(query_tokens & keyword_tokens)
+    name_hits = sorted(query_tokens & name_tokens)
+    detail_hits = sorted(query_tokens & detail_tokens)
+
+    score = len(keyword_hits) * 10 + len(name_hits) * 8 + len(detail_hits) * 3
+    reasons: list[str] = []
+    if keyword_hits:
+        reasons.append("recipe intent: " + ", ".join(keyword_hits[:4]))
+    if name_hits:
+        reasons.append("recipe name: " + ", ".join(name_hits[:3]))
+    if detail_hits:
+        reasons.append("description: " + ", ".join(detail_hits[:3]))
+
+    raw_query = " ".join(query.lower().split())
+    if raw_query and len(raw_query) >= 4 and raw_query in recipe.searchable_text():
+        score += 15
+        reasons.insert(0, "exact phrase match")
+
+    raw_tokens = profile_installer.tokenize(query)
+    pack_hits = sorted(raw_tokens & profile_installer.PACK_HINTS.get(recipe.pack, set()))
+    if pack_hits:
+        score += min(8, 2 * len(pack_hits))
+        reasons.append(f"{profile_installer.PACK_DISPLAY[recipe.pack]} intent")
+    return score, reasons
+
+
+def recommend_recipes(
+    recipes: Iterable[Recipe], query: str, *, limit: int = 5
+) -> list[tuple[Recipe, int, list[str]]]:
+    if not query.strip():
+        raise RecipeError("recommendation query cannot be empty")
+    if limit < 1:
+        raise RecipeError("--limit must be at least 1")
+    ranked: list[tuple[Recipe, int, list[str]]] = []
+    for recipe in recipes:
+        score, reasons = _score(recipe, query)
+        if score > 0:
+            ranked.append((recipe, score, reasons))
+    ranked.sort(key=lambda item: (-item[1], item[0].pack, item[0].id))
+    return ranked[:limit]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Choose a proven small Hermes team recipe without installing the whole catalog."
+    )
+    parser.add_argument("recipe", nargs="?", help="Recipe id, for example software-delivery.")
+    parser.add_argument("--list", action="store_true", help="List available recipes and exit.")
+    parser.add_argument("--recommend", metavar="TEXT", help="Recommend recipes for a plain-language goal.")
+    parser.add_argument("--tier", choices=TIER_ORDER, default="recommended", help="Recipe size tier (default: recommended).")
+    parser.add_argument("--limit", type=int, default=5, help="Maximum recipe recommendations (default: 5).")
+    parser.add_argument("--dry-run", action="store_true", help="Resolve the exact recipe profile plan without installing.")
+    parser.add_argument("--yes", action="store_true", help="Install the exact resolved recipe selection.")
+    parser.add_argument("--force", action="store_true", help="Re-apply selected distributions over existing profiles.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON and never prompt.")
+    return parser
+
+
+def _emit(payload: dict) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _recipe_plan(
+    recipe: Recipe,
+    tier: str,
+    selected: list[profile_installer.Profile],
+    all_profiles: list[profile_installer.Profile],
+) -> dict:
+    return {
+        "status": "plan",
+        "recipe": recipe.id,
+        "display_name": recipe.display_name,
+        "pack": recipe.pack,
+        "tier": tier,
+        "profiles": [profile.name for profile in selected],
+        "stats": profile_installer.selected_stats(selected, all_profiles),
+        "workflow": list(recipe.workflow),
+        "success_criteria": list(recipe.success_criteria),
+        "optional_routines": list(recipe.optional_routines),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        recipes = load_recipes()
+        packs, profiles = profile_installer.load_catalog()
+
+        read_modes = int(args.list) + int(args.recommend is not None)
+        if read_modes > 1:
+            raise RecipeError("choose only one of --list or --recommend")
+        if read_modes and args.recipe:
+            raise RecipeError("recipe id cannot be combined with --list or --recommend")
+        if read_modes and (args.dry_run or args.yes or args.force):
+            raise RecipeError("read-only recipe discovery cannot be combined with install flags")
+
+        if args.list:
+            ordered = sorted(recipes.values(), key=lambda recipe: (recipe.pack, recipe.id))
+            if args.json:
+                _emit({"recipe_count": len(ordered), "recipes": [recipe.as_dict() for recipe in ordered]})
+            else:
+                current = None
+                for recipe in ordered:
+                    if recipe.pack != current:
+                        print(f"\n{profile_installer.PACK_DISPLAY[recipe.pack]}")
+                        current = recipe.pack
+                    print(f"  {recipe.id:<28} {recipe.display_name}")
+                    print(f"    {recipe.description}")
+            return 0
+
+        if args.recommend is not None:
+            ranked = recommend_recipes(recipes.values(), args.recommend, limit=args.limit)
+            if args.json:
+                _emit(
+                    {
+                        "query": args.recommend,
+                        "recommendation_count": len(ranked),
+                        "recommendations": [
+                            {
+                                "recipe": recipe.id,
+                                "display_name": recipe.display_name,
+                                "pack": recipe.pack,
+                                "score": score,
+                                "reasons": reasons,
+                                "recommended_profiles": list(recipe.tiers["recommended"]),
+                            }
+                            for recipe, score, reasons in ranked
+                        ],
+                    }
+                )
+            else:
+                if not ranked:
+                    print("No confident recipe recommendations found.")
+                    return 0
+                print(f"Recommended team recipes for: {args.recommend}")
+                for recipe, score, reasons in ranked:
+                    print(f"  {recipe.id:<28} {recipe.display_name}  score={score}")
+                    print("    " + ("; ".join(reasons[:3]) or recipe.description))
+            return 0
+
+        if not args.recipe:
+            raise RecipeError("choose a recipe id, --list, or --recommend")
+        recipe = recipes.get(args.recipe)
+        if recipe is None:
+            raise RecipeError(f"unknown recipe: {args.recipe}")
+        selected = resolve_recipe_profiles(recipe, args.tier, profiles)
+        plan = _recipe_plan(recipe, args.tier, selected, profiles)
+
+        if args.json:
+            if args.dry_run or not args.yes:
+                _emit(plan)
+        else:
+            print(f"{recipe.display_name} [{recipe.id}] - {args.tier}")
+            print(recipe.description)
+            print("\nExact profile plan:")
+            for profile in selected:
+                print(f"  - {profile.name} ({profile.display_name})")
+            stats = plan["stats"]
+            print(
+                f"\nSelected {stats['selected_profiles']} of {stats['available_profiles']} catalog profiles "
+                f"(~{profile_installer.format_bytes(stats['estimated_source_bytes'])} source payload)."
+            )
+            if recipe.optional_routines:
+                print("\nOptional runtime ideas (never auto-installed):")
+                for routine in recipe.optional_routines:
+                    print(f"  - {routine}")
+
+        if args.dry_run or not args.yes:
+            if not args.dry_run and not args.json:
+                print("\nRead-only plan. Re-run with --yes to install this exact recipe tier.")
+            return 0
+
+        code, results = profile_installer.install_selected(
+            selected, packs, force=args.force, json_mode=args.json
+        )
+        if args.json:
+            _emit(
+                {
+                    **plan,
+                    "status": "ok" if code == 0 else "error",
+                    "returncode": code,
+                    "packs": results,
+                }
+            )
+        elif code == 0:
+            print(f"\nInstalled {len(selected)} profile(s) from recipe {recipe.id}.")
+        return code
+
+    except (RecipeError, profile_installer.CLIError, json.JSONDecodeError, OSError) as exc:
+        if args.json:
+            print(json.dumps({"status": "error", "error": str(exc)}), file=sys.stderr)
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+import io
+import json
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import install
+import recipes
+
+
+class RecipeTests(unittest.TestCase):
+    def test_registry_loads_and_ids_are_unique(self):
+        loaded = recipes.load_recipes(ROOT)
+        self.assertGreaterEqual(len(loaded), 12)
+        self.assertEqual(len(loaded), len(set(loaded)))
+
+    def test_tiers_are_monotonic_and_resolve_to_same_pack(self):
+        loaded = recipes.load_recipes(ROOT)
+        _, profiles = install.load_catalog(ROOT)
+        for recipe in loaded.values():
+            minimal = set(recipe.tiers["minimal"])
+            recommended = set(recipe.tiers["recommended"])
+            expanded = set(recipe.tiers["expanded"])
+            self.assertTrue(minimal)
+            self.assertTrue(minimal <= recommended, recipe.id)
+            self.assertTrue(recommended <= expanded, recipe.id)
+            for tier in recipes.TIER_ORDER:
+                selected = recipes.resolve_recipe_profiles(recipe, tier, profiles)
+                self.assertEqual(len(selected), len(recipe.tiers[tier]))
+                self.assertTrue(all(profile.pack == recipe.pack for profile in selected))
+
+    def test_recipe_recommendation_prefers_cybersecurity_learning_for_learning_goal(self):
+        loaded = recipes.load_recipes(ROOT)
+        ranked = recipes.recommend_recipes(loaded.values(), "learn cybersecurity", limit=3)
+        self.assertTrue(ranked)
+        self.assertEqual(ranked[0][0].id, "cybersecurity-learning")
+
+    def test_recipe_recommendation_returns_agency_software_option_for_build_goal(self):
+        loaded = recipes.load_recipes(ROOT)
+        ranked = recipes.recommend_recipes(loaded.values(), "build and ship a web app", limit=5)
+        self.assertTrue(ranked)
+        self.assertTrue(any(item[0].id == "software-delivery" for item in ranked))
+
+    def test_json_dry_run_is_read_only_and_exact(self):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            code = recipes.main(["api-backend", "--tier", "minimal", "--dry-run", "--json"])
+        self.assertEqual(code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["status"], "plan")
+        self.assertEqual(payload["recipe"], "api-backend")
+        self.assertEqual(payload["tier"], "minimal")
+        self.assertIn("agency-backend-engineer", payload["profiles"])
+        self.assertEqual(payload["stats"]["selected_profiles"], len(payload["profiles"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validate.py
+++ b/validate.py
@@ -16,20 +16,102 @@ PATTERNS = [
     ("GitHub token", re.compile(r"(?:ghp_|github_pat_)[A-Za-z0-9_]{20,}")),
     ("OpenAI-style secret", re.compile(r"(?<![A-Za-z0-9_])sk-[A-Za-z0-9_-]{20,}")),
 ]
+RECIPE_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+RECIPE_TIERS = ("minimal", "recommended", "expanded")
+
+
+def validate_recipes(profile_to_pack: dict[str, str], pack_keys: set[str]) -> list[str]:
+    errors: list[str] = []
+    path = ROOT / "recipes.json"
+    if not path.is_file():
+        return ["missing recipe registry: recipes.json"]
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"invalid recipes.json: {exc}"]
+
+    if payload.get("schema_version") != 1:
+        errors.append("recipes.json schema_version must be 1")
+    seen: set[str] = set()
+    for index, recipe in enumerate(payload.get("recipes", []), 1):
+        recipe_id = str(recipe.get("id", ""))
+        label = recipe_id or f"recipe #{index}"
+        if not RECIPE_ID.fullmatch(recipe_id):
+            errors.append(f"invalid recipe id: {label}")
+        if recipe_id in seen:
+            errors.append(f"duplicate recipe id: {recipe_id}")
+        seen.add(recipe_id)
+
+        pack = str(recipe.get("pack", ""))
+        if pack not in pack_keys:
+            errors.append(f"{label}: unknown owning pack '{pack}'")
+
+        for field in ("display_name", "description", "when_to_use"):
+            if not str(recipe.get(field, "")).strip():
+                errors.append(f"{label}: missing {field}")
+        for field in ("keywords", "workflow", "success_criteria"):
+            value = recipe.get(field)
+            if not isinstance(value, list) or not value:
+                errors.append(f"{label}: {field} must be a non-empty list")
+
+        tiers = recipe.get("tiers")
+        if not isinstance(tiers, dict):
+            errors.append(f"{label}: missing tiers object")
+            continue
+        tier_sets: dict[str, set[str]] = {}
+        for tier in RECIPE_TIERS:
+            names = tiers.get(tier)
+            if not isinstance(names, list) or not names:
+                errors.append(f"{label}: tier {tier} must be a non-empty list")
+                tier_sets[tier] = set()
+                continue
+            if len(names) != len(set(names)):
+                errors.append(f"{label}: tier {tier} contains duplicate profiles")
+            tier_sets[tier] = set(names)
+            for name in names:
+                actual_pack = profile_to_pack.get(name)
+                if actual_pack is None:
+                    errors.append(f"{label}: tier {tier} references unknown profile {name}")
+                elif actual_pack != pack:
+                    errors.append(
+                        f"{label}: tier {tier} references {name} from {actual_pack}, not owning pack {pack}"
+                    )
+        if not tier_sets["minimal"] <= tier_sets["recommended"]:
+            errors.append(f"{label}: minimal tier must be a subset of recommended")
+        if not tier_sets["recommended"] <= tier_sets["expanded"]:
+            errors.append(f"{label}: recommended tier must be a subset of expanded")
+    if not seen:
+        errors.append("recipes.json must contain at least one recipe")
+    return errors
 
 
 def main() -> int:
     errors: list[str] = []
     packs = json.loads((ROOT / "packs.json").read_text(encoding="utf-8"))["packs"]
+    profile_to_pack: dict[str, str] = {}
+    pack_keys: set[str] = set()
     for pack in packs:
         pack_dir = ROOT / pack["path"]
         if not pack_dir.is_dir():
             errors.append(f"missing pack directory: {pack['path']}")
             continue
         namespace = pack["namespace"][:-1]
+        pack_key = namespace.rstrip("-")
+        pack_keys.add(pack_key)
         manifest = ROOT / pack["manifest"]
         if not manifest.is_file():
             errors.append(f"missing pack manifest: {pack['manifest']}")
+        else:
+            try:
+                manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+                for item in manifest_payload.get("profiles", []):
+                    name = str(item.get("name", ""))
+                    if name:
+                        if name in profile_to_pack:
+                            errors.append(f"profile appears in more than one pack: {name}")
+                        profile_to_pack[name] = pack_key
+            except json.JSONDecodeError as exc:
+                errors.append(f"invalid pack manifest {pack['manifest']}: {exc}")
         profile_dir = pack_dir / "profiles"
         for child in profile_dir.iterdir():
             if child.is_dir() and not child.name.startswith(namespace):
@@ -39,6 +121,8 @@ def main() -> int:
             result = subprocess.run([sys.executable, str(validator)], cwd=pack_dir)
             if result.returncode:
                 errors.append(f"pack validator failed: {pack['name']}")
+
+    errors.extend(validate_recipes(profile_to_pack, pack_keys))
 
     for path in ROOT.rglob("*"):
         if not path.is_file() or ".git" in path.parts or "__pycache__" in path.parts or path.suffix == ".pyc":


### PR DESCRIPTION
## Summary

Adds a portable Team Operating Layer on top of the existing Profile Packs distributions without moving runtime state into this repository.

### Recipe layer
- Adds `recipes.json` with 12 validated Agency/Council/Academy team formations.
- Every recipe has minimal/recommended/expanded nested tiers, workflow guidance, success criteria, search keywords, and optional routine suggestions.
- Adds `recipes.py` for deterministic recipe listing, recommendation, exact dry-run planning, JSON output, and explicit `--yes` installation.
- Reuses the existing root installer/catalog/install functions; no second profile roster or installation implementation.

### Operating layer
- Adds first-team onboarding that defaults to the smallest useful composition.
- Adds solo/pair/team coordination guidance and the rule that chat deliberates while durable work systems record commitments.
- Adds installation verification and troubleshooting docs.
- Adds four sanitized worked examples.
- Adds optional routine guidance without auto-registering cron/runtime state.

### Orchestrator behavior
- Adds `coordination-pattern-selection` to Agency Orchestrator.
- Tightens the Orchestrator SOUL so delegation must buy distinct expertise, independent review, or useful parallelism.

### Validation
- Root `validate.py` now validates recipe IDs, owning packs, profile references, cross-pack isolation, tier monotonicity, and required recipe fields.
- Adds root tests for recipe loading, resolution, recommendation behavior, and JSON dry-run planning.

## Architectural boundary

Recipes are source-level compositions only. They do **not** create or distribute memory, learned runtime skills, sessions, Bot/group membership, Kanban state, cron jobs, credentials, model configuration, Fleet state, or machine-specific data.

## Test gate

Existing CI runs:

```bash
python validate.py
python -m unittest discover -s tests -p 'test_*.py'
python -m unittest discover -s hermes-agency/tests -p 'test_*.py'
python -m unittest discover -s hermes-council/tests -p 'test_*.py'
python -m unittest discover -s hermes-academy/tests -p 'test_*.py'
```

The PR should merge only after the exact head is green.