### PR TITLE
feat: make root installer recipe-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Hermes Profile Packs will be documented here.
 
 ### Added
 
+- Integrated Team Recipes into the canonical root `install.py` wizard and agent/script interface, including direct recipe browsing, `--list-recipes`, `--recipe`, and `--tier` selection.
+- Added confidence-aware recipe promotion: a recipe must clear both a minimum score and a minimum lead over alternatives before the installer presents it as a clear match; ambiguous goals fall back to individual profiles.
+- Added additive `recipe_match` and `recipe_recommendations` fields to `--recommend --json` while preserving the existing individual-profile `recommendations` contract.
+- Added shared `recipe_catalog.py` so `install.py` and the focused `recipes.py` client use one recipe registry/scoring/confidence implementation.
+- Added exact root-installer recipe dry-run coverage and compatibility tests, plus the detailed Recipe-Aware Root Installer implementation plan.
 - Added a validated `recipes.json` team-composition layer with minimal, recommended, and expanded tiers across Agency, Council, and Academy.
 - Added `recipes.py` for deterministic recipe discovery, recommendation, dry-run planning, JSON output, and explicit `--yes` installation through the existing profile installer.
 - Added first-team onboarding, team operating guidance, post-install verification, troubleshooting, and sanitized worked examples.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ Hermes Council currently contains 21 focused profiles and 84 purpose-built perso
 
 You rarely need all 160 profiles. Team Recipes are validated compositions of existing profiles for common outcomes, with `minimal`, `recommended`, and `expanded` tiers.
 
+The main installer understands them directly:
+
 ```bash
-python recipes.py --list
-python recipes.py --recommend "build and ship a web app"
-python recipes.py software-delivery --tier minimal --dry-run
-python recipes.py software-delivery --tier recommended --yes
+python install.py --list-recipes
+python install.py --recommend "build and ship a web app"
+python install.py --recipe software-delivery --tier minimal --dry-run
+python install.py --recipe software-delivery --tier recommended --yes
 ```
+
+Recommendation is confidence-aware. A recipe is promoted only when one formation is a strong, unambiguous fit; otherwise the installer falls back to individual profile matches instead of forcing a template.
 
 Recipes are portable selection guidance only. They do not create memory, cron jobs, Bot groups, Kanban state, credentials, or other runtime state. Installation still uses the normal Profile Packs/Hermes distribution path.
 
@@ -35,40 +39,23 @@ See [`docs/TEAM_RECIPES.md`](docs/TEAM_RECIPES.md) and [`docs/FIRST_TEAM.md`](do
 
 ```text
 hermes-profile-packs/
-├── hermes-agency/          # Professional profile pack
-│   ├── agency.json
-│   └── profiles/
-├── hermes-council/         # Personal-life profile pack
-│   ├── council.json
-│   └── profiles/
-├── hermes-academy/         # Education profile pack
-│   ├── academy.json
-│   └── profiles/
-├── docs/                   # Architecture, installer, recipes, onboarding, operating guidance
-├── examples/               # Sanitized worked team examples
-├── tests/                  # Root installer/recipe tests
+├── hermes-agency/
+├── hermes-council/
+├── hermes-academy/
+├── docs/
+├── examples/
+├── tests/
 ├── packs.json
-├── recipes.json            # Validated team composition registry
-├── install.py              # Human wizard + agent-friendly profile selector
-├── recipes.py              # Deterministic team recipe selector/installer
+├── recipes.json
+├── recipe_catalog.py       # Shared recipe loading/scoring/confidence engine
+├── install.py              # Canonical human + agent profile/recipe selector
+├── recipes.py              # Focused recipe-only convenience client
 └── validate.py
-```
-
-Each distributable profile follows the Hermes profile-distribution shape:
-
-```text
-profiles/<namespace-name>/
-├── distribution.yaml
-├── SOUL.md
-├── .no-bundled-skills      # when the profile is intentionally isolated
-└── skills/
-    └── <skill-name>/
-        └── SKILL.md
 ```
 
 Runtime state is never distributed. Authentication material, `.env` files, logs, caches, databases, local paths, session history, and machine-specific configuration do not belong in this repository.
 
-## Install individual profiles
+## Install
 
 For most people, launch the selector:
 
@@ -76,63 +63,65 @@ For most people, launch the selector:
 python install.py
 ```
 
-The wizard can recommend a small set from a plain-language goal, let you browse packs/categories, search exact profiles, or explicitly install everything. It shows the exact plan before changing Hermes and is designed to avoid installing profiles you do not need.
+The wizard can recommend a validated Team Recipe when a goal maps cleanly to one, browse recipes directly, browse packs/categories, search exact profiles, or explicitly install everything. A recipe is never silently chosen: the user chooses its tier and sees the exact profile plan before final confirmation.
 
-The existing pack-first commands are still supported:
-
-```bash
-python install.py --list-packs
-python install.py council --list
-python install.py agency --list
-python install.py academy --list
-python install.py council council-life-coach council-fitness-coach
-python install.py academy academy-cybersecurity-instructor academy-physics-professor
-```
-
-For agents and scripts, the same selector exposes a deterministic JSON interface:
+For agents and scripts:
 
 ```bash
 python install.py --agent-help --json
 python install.py --catalog --json
+python install.py --list-recipes --json
 python install.py --recommend "build a web app" --json
+python install.py --recipe software-delivery --tier minimal --dry-run --json
+python install.py --recipe software-delivery --tier recommended --yes --json
 python install.py --profiles agency-backend-engineer agency-frontend-engineer --dry-run --json
-python install.py --profiles agency-backend-engineer agency-frontend-engineer --yes --json
 python install.py --all --yes --json
 ```
 
-`--catalog` and `--recommend` are read-only. Non-interactive installation requires `--yes`, and `--dry-run` resolves the exact plan first. Installation still delegates to each pack's native `hermes profile install` flow.
+`--catalog`, `--list-recipes`, and `--recommend` are read-only. Existing `--recommend --json` consumers keep the individual-profile `recommendations` array; recipe results are additive through `recipe_match` and `recipe_recommendations`.
 
-See [`docs/INSTALLER.md`](docs/INSTALLER.md) for the full wizard and agent contract.
+Legacy pack-first commands remain supported.
+
+See [`docs/INSTALLER.md`](docs/INSTALLER.md) for the full contract.
+
+## Focused recipe client
+
+`recipes.py` remains supported when a recipe-only surface is convenient:
+
+```bash
+python recipes.py --list
+python recipes.py --recommend "learn cybersecurity"
+python recipes.py cybersecurity-learning --tier recommended --dry-run
+```
+
+Both entry points use the same shared recipe engine.
 
 ## Operate the team
 
-Once profiles are installed, use [`docs/OPERATING_PLAYBOOK.md`](docs/OPERATING_PLAYBOOK.md) for solo/pair/team selection, durable handoffs, the "chat deliberates; durable systems commit" rule, and optional routine guidance.
-
-Use [`docs/INSTALLATION_VERIFICATION.md`](docs/INSTALLATION_VERIFICATION.md) to verify a real install and [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) when adoption goes sideways.
+Use [`docs/OPERATING_PLAYBOOK.md`](docs/OPERATING_PLAYBOOK.md), [`docs/INSTALLATION_VERIFICATION.md`](docs/INSTALLATION_VERIFICATION.md), and [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md).
 
 ## Validate
-
-Run the full repository validation suite before publishing changes:
 
 ```bash
 python validate.py
 python -m unittest discover -s tests -p 'test_*.py'
 ```
 
-This validates all registered pack manifests, profile namespaces, distribution metadata, required profile files, skill frontmatter, portability, common secret/path leaks, team recipe references/tier invariants, and root selector behavior. Pack-specific validators and tests enforce additional contracts.
+This validates pack manifests, namespaces, distribution metadata, skills, portability, secret/path hygiene, team recipe references/tier invariants, and root selector behavior.
 
 ## Design principles
 
 1. **Coherent teams, not prompt dumps.** Profiles have explicit ownership and clean handoffs.
 2. **Namespace isolation.** `agency-*` is professional, `council-*` is personal, and `academy-*` is educational.
 3. **Portable distributions only.** No runtime state, secrets, personal filesystem paths, or local caches.
-4. **Specialists remain specialists.** Profiles should hand off rather than silently absorbing unrelated domains.
-5. **Smallest useful team.** Recipes and orchestrators should add profiles only for distinct expertise, independent review, or useful parallelism.
-6. **Human agency stays central.** Council profiles support decisions and capability; they do not attempt to run a person's life.
-7. **Safety beats role-play.** Profiles do not manufacture medical, legal, financial, spiritual, parental, credentialing, or other authority they do not possess.
-8. **Academy teaches for transfer.** Explanations, examples, practice, feedback, and mastery checks should make the learner progressively more capable rather than merely dependent on answers.
+4. **Specialists remain specialists.** Profiles hand off rather than silently absorbing unrelated domains.
+5. **Smallest useful team.** Add profiles only for distinct expertise, independent review, or useful parallelism.
+6. **Conservative recommendation.** A recipe is promoted only when the deterministic match is strong and unambiguous.
+7. **Human agency stays central.** Council supports decisions and capability; it does not run a person's life.
+8. **Safety beats role-play.** Profiles do not manufacture authority they do not possess.
+9. **Academy teaches for transfer.** Teaching should make the learner progressively more capable.
 
-See [`PACK_SPEC.md`](PACK_SPEC.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), and [`SECURITY.md`](SECURITY.md) for repository standards.
+See [`PACK_SPEC.md`](PACK_SPEC.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), and [`SECURITY.md`](SECURITY.md).
 
 ## License
 

--- a/docs/FIRST_TEAM.md
+++ b/docs/FIRST_TEAM.md
@@ -10,25 +10,29 @@ Examples:
 - "Help me reset my routines and priorities."
 - "Teach me defensive cybersecurity."
 
-Ask the recipe selector:
+Ask the main installer:
 
 ```bash
-python recipes.py --recommend "build and ship a web feature"
+python install.py --recommend "build and ship a web feature"
 ```
 
-Then inspect the recommended recipe before installing:
+If one Team Recipe is a strong, unambiguous match, the installer promotes it. If the goal is broad or several recipes are plausible, it keeps the recommendation at the individual-profile level instead of forcing a formation.
+
+Inspect the recipe before installing:
 
 ```bash
-python recipes.py software-delivery --tier minimal --dry-run
+python install.py --recipe software-delivery --tier minimal --dry-run
 ```
 
 ## 2. Install the smallest coherent tier
 
 ```bash
-python recipes.py software-delivery --tier minimal --yes
+python install.py --recipe software-delivery --tier minimal --yes
 ```
 
 Do not upgrade to `recommended` or `expanded` because the names look useful. Add roles when the work actually crosses into their specialty, when independent review is justified, or when a clean parallel seam exists.
+
+You can also run `python install.py` and use the interactive recipe-aware wizard.
 
 ## 3. Prove one real workflow
 

--- a/docs/INSTALLATION_VERIFICATION.md
+++ b/docs/INSTALLATION_VERIFICATION.md
@@ -9,10 +9,14 @@ No undocumented Hermes flags are required by this guide.
 The selected pack installer must finish without an error. If recipe installation is used, inspect the exact plan first:
 
 ```bash
-python recipes.py software-delivery --tier minimal --dry-run
+python install.py --recipe software-delivery --tier minimal --dry-run
 ```
 
-Then install that exact tier with `--yes`.
+Then install that exact tier with `--yes`:
+
+```bash
+python install.py --recipe software-delivery --tier minimal --yes
+```
 
 ## 2. Presence
 

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -1,13 +1,13 @@
 # Profile Selector & Installer
 
-The root `install.py` is the recommended entry point for installing Hermes Profile Packs.
+The root `install.py` is the recommended entry point for discovering and installing Hermes Profile Packs. It understands both individual profiles and validated Team Recipes.
 
-It has two surfaces backed by the same catalog:
+It has two surfaces backed by the same profile manifests and `recipes.json` registry:
 
 - an interactive wizard for people;
 - a deterministic non-interactive interface for agents and scripts.
 
-The installer reads `packs.json`, each pack manifest, and existing profile distribution metadata. It does not maintain a second profile roster.
+No second profile roster exists. Recipe installation resolves stable profile identities and then uses the same pack installers as direct profile installation.
 
 ## Interactive wizard
 
@@ -17,20 +17,53 @@ Run:
 python install.py
 ```
 
-The wizard offers four paths:
+The wizard offers five useful paths plus exit:
 
-1. **Recommend a small set for me** — describe what you want Hermes to help with and review the best matching profiles.
-2. **Browse packs and categories** — choose a pack, category, and exact profiles.
-3. **Search profiles directly** — search profile names, roles, jobs, and descriptions.
-4. **Install everything** — explicitly install the complete catalog.
-
-The default philosophy is sparse installation. Recommendations are intentionally bounded, and the wizard shows the exact plan before installation. It also estimates how much profile-distribution payload is selected versus skipped.
+1. **Recommend a small team for me** — describe the outcome. A clear Team Recipe is offered first when one is strongly and unambiguously matched; otherwise the wizard falls back to individual profiles.
+2. **Browse team recipes** — choose a proven composition and then `minimal`, `recommended`, or `expanded`.
+3. **Browse packs and categories** — choose a pack, category, and exact profiles.
+4. **Search profiles directly** — search profile names, roles, jobs, and descriptions.
+5. **Install everything** — explicitly install the complete catalog.
 
 Nothing is installed until the final confirmation.
 
-## Existing pack commands still work
+## Recipe-aware recommendation
 
-The previous pack-first interface is preserved:
+Recipe promotion is intentionally conservative. The installer does not equate “highest score” with “correct team.” A recipe is promoted only when it clears both a minimum score and a minimum lead over the runner-up.
+
+That means:
+
+- `build and ship a web app` can cleanly map to the Software Delivery Team;
+- `learn cybersecurity` can cleanly map to Cybersecurity Learning;
+- a broad or mixed request may show only individual profile matches because no single recipe dominates strongly enough.
+
+When a recipe is offered interactively, you can decline it and immediately continue with individual profile selection.
+
+## Browse recipes from the root installer
+
+```bash
+python install.py --list-recipes
+python install.py --list-recipes --json
+python install.py --list-recipes --pack agency
+```
+
+Recipe tiers are nested:
+
+- `minimal` — smallest coherent formation;
+- `recommended` — default balance of expertise and independent review;
+- `expanded` — broader coverage for larger or higher-risk work.
+
+Preview or install a recipe directly:
+
+```bash
+python install.py --recipe software-delivery --tier minimal --dry-run
+python install.py --recipe software-delivery --tier recommended --dry-run --json
+python install.py --recipe software-delivery --tier recommended --yes
+```
+
+If `--tier` is omitted, `recommended` is used. `--recipe` cannot be combined with `--profiles`, `--category`, or `--all`.
+
+## Existing pack commands still work
 
 ```bash
 python install.py agency --list
@@ -44,27 +77,26 @@ These commands delegate directly to the existing pack installers.
 
 ## Agent and script interface
 
-Agents should not drive the interactive prompt. Use the machine-readable interface instead.
-
-Discover the contract:
+Agents should not drive the interactive prompt. Discover the machine contract with:
 
 ```bash
 python install.py --agent-help --json
 ```
 
-Inspect the full catalog:
+Profile catalog:
 
 ```bash
 python install.py --catalog --json
-```
-
-Limit discovery to one pack:
-
-```bash
 python install.py --catalog --pack council --json
 ```
 
-Ask for deterministic recommendations without installing anything:
+Recipe catalog:
+
+```bash
+python install.py --list-recipes --json
+```
+
+Recommendation:
 
 ```bash
 python install.py --recommend "build a web app" --json
@@ -72,76 +104,81 @@ python install.py --recommend "learn cybersecurity" --json
 python install.py --recommend "improve my fitness and recovery" --json
 ```
 
-Recommendations return exact profile names, scores, match reasons, pack/category metadata, and estimated source size. Recommendation mode is read-only.
+For backward compatibility, `recommendations` remains the individual-profile result list. Recipe information is additive:
 
-Preview an exact selection:
+- `recipe_match` — the promoted recipe, or `null` when confidence is insufficient;
+- `recipe_recommendations` — ranked recipe candidates;
+- `recommendations` — the existing individual-profile candidates.
 
-```bash
-python install.py \
-  --profiles agency-backend-engineer agency-frontend-engineer \
-  --dry-run \
-  --json
-```
+Recommendation mode is always read-only.
 
-Install an exact selection:
+Exact profile dry-run/install:
 
 ```bash
 python install.py \
   --profiles agency-backend-engineer agency-frontend-engineer \
-  --yes \
-  --json
+  --dry-run --json
+
+python install.py \
+  --profiles agency-backend-engineer agency-frontend-engineer \
+  --yes --json
 ```
 
-Install a category:
+Recipe dry-run/install:
+
+```bash
+python install.py \
+  --recipe api-backend \
+  --tier minimal \
+  --dry-run --json
+
+python install.py \
+  --recipe api-backend \
+  --tier minimal \
+  --yes --json
+```
+
+Categories and full-pack selection still work:
 
 ```bash
 python install.py --category council:growth --yes --json
-```
-
-Install multiple categories:
-
-```bash
-python install.py \
-  --category agency:engineering \
-  --category agency:qa \
-  --yes \
-  --json
-```
-
-Install every profile in one pack:
-
-```bash
 python install.py --all --pack academy --yes --json
-```
-
-Install the entire repository:
-
-```bash
 python install.py --all --yes --json
 ```
 
 ## Non-interactive safety rules
 
-- `--catalog` and `--recommend` never install anything.
+- `--catalog`, `--list-recipes`, and `--recommend` never install anything.
 - `--dry-run` resolves the exact selection without changing Hermes.
 - Non-interactive writes require `--yes`.
 - `--json` never prompts.
-- Unknown profile names and invalid `PACK:CATEGORY` selectors fail closed with exit code `2`.
+- Unknown profiles, recipes, tiers, and invalid `PACK:CATEGORY` selectors fail closed.
 - Explicit profile selections are deduplicated before installation.
+- Recipe/profile/category/all selection modes are mutually exclusive where they would conflict.
 - Installation continues to use each pack's existing native `hermes profile install` flow.
 
-A safe agent pattern is therefore:
+A safe agent pattern is:
 
-1. `--catalog --json` or `--recommend ... --json`;
-2. choose exact profile names;
-3. `--dry-run --json`;
-4. verify the returned plan;
-5. repeat the exact selection with `--yes --json`.
+1. inspect `--recommend --json`, `--list-recipes --json`, or `--catalog --json`;
+2. choose an exact recipe/tier or profile set;
+3. run `--dry-run --json`;
+4. verify the returned exact plan;
+5. repeat with `--yes --json`.
 
-## Recommendation behavior
+## Focused recipe CLI
 
-Recommendations are local and deterministic. They score the existing catalog using profile names, display names, categories, descriptions, roles, jobs, pack intent, and a small vocabulary-expansion map for common terms such as web, API, security, fitness, finance, and learning.
+`recipes.py` remains supported for callers who want a recipe-only surface:
 
-This is deliberately not an LLM call. The selector remains fast, offline, inspectable, and predictable for both humans and agents.
+```bash
+python recipes.py --list
+python recipes.py --recommend "build and ship a web app"
+python recipes.py software-delivery --tier recommended --dry-run
+```
 
-The recommendation result is advice, not an installation decision. The user or calling agent still chooses the exact profiles to install.
+Both entry points use the same shared recipe engine. `install.py` is the preferred general entry point; `recipes.py` is a focused convenience client.
+
+## Recommendation implementation
+
+Recommendations are local, deterministic, offline, and inspectable. Profile scoring uses names, categories, descriptions, roles, jobs, pack intent, and vocabulary expansion. Recipe scoring uses the same query vocabulary against recipe names, keywords, descriptions, and pack intent.
+
+A recipe is advice, not authority. The user or calling agent still chooses the exact recipe/tier or profile selection to install.

--- a/docs/RECIPE_AWARE_INSTALLER_PLAN.md
+++ b/docs/RECIPE_AWARE_INSTALLER_PLAN.md
@@ -1,0 +1,187 @@
+# Recipe-Aware Root Installer Plan
+
+Status: implementation target for `feat/recipe-aware-installer`.
+
+## Goal
+
+Make the root `install.py` the canonical discovery surface for both individual profiles and validated Team Recipes, without collapsing the two concepts or breaking existing agent/script consumers.
+
+The installer should answer a plain-language goal in two stages:
+
+1. Does this map strongly and unambiguously to a known recipe?
+2. Regardless of recipe fit, which individual profiles match the goal?
+
+A recipe is promoted only when it clears a deterministic confidence gate. Ambiguous goals fall back to the existing profile-level recommendation experience.
+
+## Invariants
+
+- `recipes.json` remains the canonical recipe registry.
+- Pack manifests remain the canonical profile rosters.
+- No duplicate profile catalog is introduced.
+- Recipe scoring has one implementation shared by `install.py` and `recipes.py`.
+- `--recommend` remains read-only.
+- Existing JSON key `recommendations` remains the individual-profile list for backward compatibility.
+- Recipe information is additive through `recipe_match` and `recipe_recommendations`.
+- Installation still delegates to existing pack installers and Hermes-native `hermes profile install`.
+- Recipe selection never creates runtime memory, cron, groups, Kanban state, credentials, model config, or Fleet state.
+- Legacy pack-first commands remain supported.
+
+## Phase 1: Extract shared recipe engine
+
+Create `recipe_catalog.py` as the dependency-neutral recipe core.
+
+It owns:
+
+- `Recipe` and `RecipeError`;
+- registry loading;
+- tier constants;
+- profile resolution by recipe/tier;
+- recipe scoring;
+- recipe ranking;
+- confidence policy.
+
+It does not import `install.py`. Callers supply the existing profile-query expansion/tokenization and pack-intent maps, avoiding a circular import while retaining one recipe scoring implementation.
+
+Acceptance:
+
+- `recipes.py` and `install.py` both call the same scoring and confidence code.
+- Existing recipe CLI behavior remains available.
+
+## Phase 2: Define a conservative confidence gate
+
+A recipe should not be promoted merely because it has the highest score.
+
+Default gate:
+
+- top score must be at least 24;
+- top recipe must beat the second recipe by at least 8 points.
+
+This intentionally prefers a false negative over a false positive. If several recipes are plausible, the installer should show profile-level matches rather than pretending one formation is canonical.
+
+Acceptance:
+
+- `build and ship a web app` promotes `software-delivery`.
+- `learn cybersecurity` promotes `cybersecurity-learning`.
+- low-score or closely tied synthetic rankings do not produce a confident recipe match.
+
+## Phase 3: Upgrade interactive recommendation
+
+Change wizard option 1 from profile-only matching to recipe-aware matching.
+
+Flow:
+
+1. user describes the goal;
+2. score recipes and profiles independently;
+3. if one recipe clears the confidence gate, show it first with explanation;
+4. user may accept or decline;
+5. if accepted, choose `minimal`, `recommended`, or `expanded`;
+6. show exact profiles;
+7. continue to the existing final install confirmation;
+8. if declined or no recipe is confident, show individual profile matches exactly as before.
+
+The wizard must never silently choose a tier or install a recipe.
+
+## Phase 4: Add direct recipe browsing to the wizard
+
+Add a dedicated `Browse team recipes` path.
+
+The main menu becomes:
+
+1. Recommend a small team for me
+2. Browse team recipes
+3. Browse packs and categories
+4. Search profiles directly
+5. Install everything
+6. Exit
+
+Recipe browsing shows pack, purpose, and tier sizes. The user chooses one recipe and one tier before the normal install confirmation.
+
+## Phase 5: Add recipe selection to the root CLI
+
+Add:
+
+```bash
+python install.py --list-recipes
+python install.py --list-recipes --json
+python install.py --recipe software-delivery --tier minimal --dry-run
+python install.py --recipe software-delivery --tier recommended --yes --json
+```
+
+Rules:
+
+- `--recipe` is mutually exclusive with `--profiles`, `--category`, and `--all`;
+- `--tier` requires `--recipe`;
+- omitted tier defaults to `recommended`;
+- `--pack` may filter recipe discovery and must reject a recipe outside the requested pack;
+- dry-run uses the same exact plan/stats machinery as profile selection;
+- non-interactive writes still require `--yes`.
+
+## Phase 6: Preserve agent/script compatibility
+
+Existing profile recommendation JSON remains:
+
+```json
+{
+  "recommendations": [ ...profile results... ]
+}
+```
+
+Additive fields:
+
+```json
+{
+  "recipe_match": { ... } | null,
+  "recipe_recommendations": [ ... ]
+}
+```
+
+`recipe_match` exists only when the confidence gate passes.
+
+Update `--agent-help --json` with recipe discovery, dry-run, and install examples.
+
+## Phase 7: Keep the focused recipe CLI
+
+`recipes.py` remains supported as a recipe-first convenience surface.
+
+It should become a thin client over `recipe_catalog.py` plus the root installer's profile/install primitives. This keeps existing documentation and scripts working while making `install.py` the preferred all-purpose entry point.
+
+## Phase 8: Tests
+
+Add deterministic coverage for:
+
+- shared registry loading;
+- tier monotonicity and same-pack resolution;
+- strong recipe recommendation;
+- confidence minimum score;
+- confidence minimum margin;
+- root `recommend_goal` promoting a clear recipe while still returning profile matches;
+- root `--recommend --json` preserving `recommendations` and adding recipe fields;
+- root `--recipe ... --dry-run --json` exact resolution;
+- standalone `recipes.py` dry-run regression.
+
+Existing installer, Agency, Council, and Academy suites remain part of the gate.
+
+## Phase 9: Documentation
+
+Update:
+
+- root README;
+- `docs/INSTALLER.md`;
+- `docs/TEAM_RECIPES.md`;
+- changelog.
+
+Document the confidence behavior explicitly so users understand that “no recipe promoted” means “no single recipe was sufficiently unambiguous,” not “recipes are unavailable.”
+
+## Release gate
+
+Required exact-head CI:
+
+```bash
+python validate.py
+python -m unittest discover -s tests -p 'test_*.py'
+python -m unittest discover -s hermes-agency/tests -p 'test_*.py'
+python -m unittest discover -s hermes-council/tests -p 'test_*.py'
+python -m unittest discover -s hermes-academy/tests -p 'test_*.py'
+```
+
+Merge only after the pull-request head passes the full gate.

--- a/docs/TEAM_RECIPES.md
+++ b/docs/TEAM_RECIPES.md
@@ -1,48 +1,64 @@
 # Team Recipes
 
-Team recipes are validated, portable compositions of existing Hermes Profile Packs profiles. They answer a practical question: **which small set should I install for this kind of outcome?**
+Team Recipes are validated, portable compositions of existing Hermes Profile Packs profiles. They answer: **which small set should I install for this kind of outcome?**
 
-A recipe does not create a new agent type, scheduler, room, board, memory store, or runtime. It resolves stable profile identities and delegates installation to the existing Profile Packs installer.
+A recipe does not create a new agent type, scheduler, room, board, memory store, or runtime. It resolves stable profile identities and delegates installation to the existing Profile Packs/Hermes distribution path.
 
-## Browse and recommend
+## Recommended entry point
+
+The root installer now understands recipes directly:
 
 ```bash
-python recipes.py --list
-python recipes.py --list --json
-python recipes.py --recommend "build and ship a web app"
-python recipes.py --recommend "learn cybersecurity" --json
+python install.py --list-recipes
+python install.py --recommend "build and ship a web app"
+python install.py --recipe software-delivery --tier minimal --dry-run
+python install.py --recipe software-delivery --tier recommended --yes
 ```
+
+The interactive wizard (`python install.py`) can also recommend a recipe, browse recipes, choose a tier, and show the exact final install plan.
+
+## Confidence-aware promotion
+
+The installer promotes a Team Recipe only when the match is both strong and unambiguous. A top-scoring recipe that is weak or nearly tied with another recipe is not presented as canonical.
+
+This matters because recipes represent opinionated team formations. Ambiguity should fall back to individual profile discovery rather than forcing the user's goal into the wrong template.
+
+`--recommend --json` exposes:
+
+- `recipe_match`: one clear promoted recipe or `null`;
+- `recipe_recommendations`: ranked recipe candidates;
+- `recommendations`: individual profile candidates.
 
 ## Tiers
 
 Every recipe has three nested tiers:
 
-- **minimal**: the smallest coherent set that can perform the core workflow;
-- **recommended**: the default balance of expertise, review, and coordination;
+- **minimal**: smallest coherent set that can perform the core workflow;
+- **recommended**: default balance of expertise, review, and coordination;
 - **expanded**: additional distinct specialties for larger or higher-risk work.
 
-Bigger is not automatically better. Use the smallest tier that adds real expertise or independent verification.
+Bigger is not automatically better. Use the smallest tier that adds real expertise, independent verification, or useful parallelism.
 
 ## Inspect before installing
 
 ```bash
-python recipes.py software-delivery --tier minimal
-python recipes.py software-delivery --tier recommended --dry-run
-python recipes.py security-review --tier recommended --dry-run --json
+python install.py --recipe software-delivery --tier minimal --dry-run
+python install.py --recipe security-review --tier recommended --dry-run --json
 ```
 
-Without `--yes`, recipe selection is read-only. The plan shows exact profile names, source-payload estimates, workflow guidance, success criteria, and optional runtime ideas.
+Without `--yes`, the selection is read-only. The plan shows exact profile names, source-payload estimates, workflow guidance, success criteria, and optional runtime ideas.
 
-## Install
+## Focused recipe client
+
+`recipes.py` remains available:
 
 ```bash
-python recipes.py software-delivery --tier recommended --yes
-python recipes.py api-backend --tier minimal --yes
-python recipes.py personal-reset --tier minimal --yes
-python recipes.py cybersecurity-learning --tier recommended --yes
+python recipes.py --list
+python recipes.py --recommend "learn cybersecurity" --json
+python recipes.py personal-reset --tier minimal --dry-run
 ```
 
-Installation reuses the root installer and each pack's normal `hermes profile install` path. Recipe tooling does not maintain a second profile catalog.
+It uses the same shared recipe engine as `install.py`; it does not maintain independent scoring or a second profile roster.
 
 ## Initial catalog
 

--- a/install.py
+++ b/install.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python3
 """Discover, recommend, and install Hermes Profile Packs.
 
-Run with no arguments in a terminal for the interactive wizard. Existing
-pack-first commands remain supported, for example::
-
-    python install.py council --list
-    python install.py agency agency-backend-engineer
-
-For agents and scripts, use the non-interactive catalog/recommend/selection
-flags together with --json where machine-readable output is useful.
+Run with no arguments in a terminal for the interactive wizard. Existing pack-first
+commands remain supported. Recommendation is recipe-aware: strong, unambiguous goals
+surface a validated Team Recipe first, while ambiguous goals fall back to individual
+profile matching.
 """
 
 from __future__ import annotations
@@ -22,951 +18,396 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
+import recipe_catalog
+
 ROOT = Path(__file__).resolve().parent
 PACK_FILE = ROOT / "packs.json"
-PACK_ALIASES = {
-    "agency": "agency",
-    "hermes-agency": "agency",
-    "council": "council",
-    "hermes-council": "council",
-    "academy": "academy",
-    "hermes-academy": "academy",
-}
-PACK_DISPLAY = {
-    "agency": "Hermes Agency",
-    "council": "Hermes Council",
-    "academy": "Hermes Academy",
-}
+PACK_ALIASES = {"agency":"agency","hermes-agency":"agency","council":"council","hermes-council":"council","academy":"academy","hermes-academy":"academy"}
+PACK_DISPLAY = {"agency":"Hermes Agency","council":"Hermes Council","academy":"Hermes Academy"}
 PACK_HINTS = {
-    "agency": {
-        "build", "work", "professional", "project", "software", "code", "coding",
-        "develop", "development", "design", "product", "marketing", "business",
-        "deploy", "devops", "engineering", "test", "qa", "content", "support",
-    },
-    "council": {
-        "life", "personal", "health", "fitness", "parent", "parenting", "family",
-        "relationship", "finance", "budget", "faith", "sleep", "home", "career",
-        "travel", "nutrition", "stress", "time", "focus", "community", "recreation",
-    },
-    "academy": {
-        "learn", "study", "teach", "teacher", "professor", "course", "class",
-        "education", "practice", "understand", "school", "training", "lesson",
-    },
+    "agency": {"build","work","professional","project","software","code","coding","develop","development","design","product","marketing","business","deploy","devops","engineering","test","qa","content","support"},
+    "council": {"life","personal","health","fitness","parent","parenting","family","relationship","finance","budget","faith","sleep","home","career","travel","nutrition","stress","time","focus","community","recreation"},
+    "academy": {"learn","study","teach","teacher","professor","course","class","education","practice","understand","school","training","lesson"},
 }
 QUERY_EXPANSIONS = {
-    "api": {"backend", "integration", "web"},
-    "web": {"frontend", "backend", "fullstack", "full-stack"},
-    "website": {"frontend", "backend", "fullstack", "full-stack"},
-    "app": {"application", "frontend", "backend"},
-    "apps": {"application", "frontend", "backend"},
-    "software": {"engineering", "architect", "developer"},
-    "code": {"engineering", "developer", "programming"},
-    "coding": {"engineering", "developer", "programming"},
-    "developer": {"engineering", "programming"},
-    "security": {"cybersecurity", "threat", "privacy", "secure"},
-    "cyber": {"cybersecurity", "security", "threat"},
-    "ai": {"mlops", "machine", "learning", "data"},
-    "ml": {"mlops", "machine", "learning", "data"},
-    "ui": {"ux", "frontend", "design", "interface"},
-    "ux": {"ui", "design", "product"},
-    "cloud": {"systems", "infrastructure", "devops", "reliability"},
-    "ops": {"operations", "devops", "infrastructure", "reliability"},
-    "sre": {"reliability", "site", "infrastructure"},
-    "game": {"godot", "worldbuilder", "level", "game"},
-    "games": {"godot", "worldbuilder", "level", "game"},
-    "money": {"finance", "budget", "financial"},
-    "finances": {"finance", "budget", "financial"},
-    "parent": {"parenting", "family"},
-    "kids": {"parenting", "family", "children"},
-    "children": {"parenting", "family"},
-    "workout": {"fitness", "movement", "training"},
-    "exercise": {"fitness", "movement", "training"},
-    "food": {"nutrition", "culinary", "meal"},
-    "cooking": {"culinary", "food", "recipe"},
-    "stress": {"resilience", "recovery", "coping"},
-    "focus": {"attention", "time", "planning"},
-    "religion": {"faith", "theology", "religious"},
-    "christian": {"faith", "theology"},
-    "math": {"mathematics", "quantitative"},
-    "stats": {"statistics", "quantitative"},
-    "car": {"automotive"},
-    "cars": {"automotive"},
-    "writing": {"writer", "rhetoric", "content"},
-    "write": {"writer", "rhetoric", "content"},
-    "research": {"research", "evidence", "methods"},
-    "legal": {"law"},
-    "law": {"legal"},
-    "music": {"music"},
-    "art": {"arts", "design", "creative"},
+    "api":{"backend","integration","web"},"web":{"frontend","backend","fullstack","full-stack"},"website":{"frontend","backend","fullstack","full-stack"},"app":{"application","frontend","backend"},"apps":{"application","frontend","backend"},"software":{"engineering","architect","developer"},"code":{"engineering","developer","programming"},"coding":{"engineering","developer","programming"},"developer":{"engineering","programming"},"security":{"cybersecurity","threat","privacy","secure"},"cyber":{"cybersecurity","security","threat"},"ai":{"mlops","machine","learning","data"},"ml":{"mlops","machine","learning","data"},"ui":{"ux","frontend","design","interface"},"ux":{"ui","design","product"},"cloud":{"systems","infrastructure","devops","reliability"},"ops":{"operations","devops","infrastructure","reliability"},"sre":{"reliability","site","infrastructure"},"game":{"godot","worldbuilder","level","game"},"games":{"godot","worldbuilder","level","game"},"money":{"finance","budget","financial"},"finances":{"finance","budget","financial"},"parent":{"parenting","family"},"kids":{"parenting","family","children"},"children":{"parenting","family"},"workout":{"fitness","movement","training"},"exercise":{"fitness","movement","training"},"food":{"nutrition","culinary","meal"},"cooking":{"culinary","food","recipe"},"stress":{"resilience","recovery","coping"},"focus":{"attention","time","planning"},"religion":{"faith","theology","religious"},"christian":{"faith","theology"},"math":{"mathematics","quantitative"},"stats":{"statistics","quantitative"},"car":{"automotive"},"cars":{"automotive"},"writing":{"writer","rhetoric","content"},"write":{"writer","rhetoric","content"},"research":{"research","evidence","methods"},"legal":{"law"},"law":{"legal"},"music":{"music"},"art":{"arts","design","creative"},
 }
-COORDINATION_TERMS = {
-    "coordinate", "coordination", "orchestrate", "orchestrator", "steward", "dean",
-    "team", "overview", "general", "everything", "whole", "manage", "management",
-}
+COORDINATION_TERMS = {"coordinate","coordination","orchestrate","orchestrator","steward","dean","team","overview","general","everything","whole","manage","management"}
 TOKEN_RE = re.compile(r"[a-z0-9]+")
 
-
-class CLIError(ValueError):
-    """User-facing CLI error."""
-
+class CLIError(ValueError): pass
 
 @dataclass(frozen=True)
 class PackInfo:
-    key: str
-    name: str
-    path: Path
-    namespace: str
-    manifest_path: Path
-    purpose: str
-    version: str
-    orchestrator: str | None
-    backbone: frozenset[str]
-    categories: tuple[str, ...]
-    profile_names: tuple[str, ...]
-
+    key:str; name:str; path:Path; namespace:str; manifest_path:Path; purpose:str; version:str; orchestrator:str|None; backbone:frozenset[str]; categories:tuple[str,...]; profile_names:tuple[str,...]
 
 @dataclass(frozen=True)
 class Profile:
-    pack: str
-    pack_name: str
-    name: str
-    display_name: str
-    category: str
-    description: str
-    role: str
-    jobs: tuple[str, ...]
-    orchestrator: bool
-    backbone: bool
-    source_bytes: int
+    pack:str; pack_name:str; name:str; display_name:str; category:str; description:str; role:str; jobs:tuple[str,...]; orchestrator:bool; backbone:bool; source_bytes:int
+    def searchable_text(self)->str: return " ".join([self.name.replace("-"," "),self.display_name,self.category,self.description,self.role,*self.jobs]).lower()
+    def as_dict(self)->dict: return {"pack":self.pack,"pack_name":self.pack_name,"name":self.name,"display_name":self.display_name,"category":self.category,"description":self.description,"role":self.role,"jobs":list(self.jobs),"orchestrator":self.orchestrator,"backbone":self.backbone,"estimated_source_bytes":self.source_bytes}
 
-    def searchable_text(self) -> str:
-        return " ".join(
-            [
-                self.name.replace("-", " "),
-                self.display_name,
-                self.category,
-                self.description,
-                self.role,
-                *self.jobs,
-            ]
-        ).lower()
+def normalize_pack(value:str)->str:
+    try: return PACK_ALIASES[value.strip().lower()]
+    except KeyError as exc: raise CLIError(f"unknown pack: {value}") from exc
 
-    def as_dict(self) -> dict:
-        return {
-            "pack": self.pack,
-            "pack_name": self.pack_name,
-            "name": self.name,
-            "display_name": self.display_name,
-            "category": self.category,
-            "description": self.description,
-            "role": self.role,
-            "jobs": list(self.jobs),
-            "orchestrator": self.orchestrator,
-            "backbone": self.backbone,
-            "estimated_source_bytes": self.source_bytes,
-        }
+def short_pack_name(name:str)->str:
+    return normalize_pack(name[len("hermes-"):] if name.startswith("hermes-") else name)
 
-
-def normalize_pack(value: str) -> str:
-    try:
-        return PACK_ALIASES[value.strip().lower()]
-    except KeyError as exc:
-        raise CLIError(f"unknown pack: {value}") from exc
-
-
-def short_pack_name(name: str) -> str:
-    if name.startswith("hermes-"):
-        name = name[len("hermes-") :]
-    return normalize_pack(name)
-
-
-def _yaml_scalar(path: Path, key: str) -> str:
-    if not path.is_file():
-        return ""
-    prefix = f"{key}:"
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line.startswith(prefix):
-            continue
-        value = line.split(":", 1)[1].strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
-            value = value[1:-1]
-        return value.replace(r'\"', '"')
+def _yaml_scalar(path:Path,key:str)->str:
+    if not path.is_file(): return ""
+    prefix=f"{key}:"
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line=raw.strip()
+        if line.startswith(prefix):
+            value=line.split(":",1)[1].strip()
+            if len(value)>=2 and value[0]==value[-1] and value[0] in {'"',"'"}: value=value[1:-1]
+            return value.replace(r'\"','"')
     return ""
 
-
-def directory_size(path: Path) -> int:
-    total = 0
-    if not path.is_dir():
-        return 0
+def directory_size(path:Path)->int:
+    total=0
+    if not path.is_dir(): return 0
     for child in path.rglob("*"):
         try:
-            if child.is_file():
-                total += child.stat().st_size
-        except OSError:
-            continue
+            if child.is_file(): total+=child.stat().st_size
+        except OSError: continue
     return total
 
+def load_catalog(root:Path=ROOT)->tuple[dict[str,PackInfo],list[Profile]]:
+    pack_file=root/"packs.json"
+    if not pack_file.is_file(): raise CLIError(f"missing pack registry: {pack_file}")
+    registry=json.loads(pack_file.read_text(encoding="utf-8")); packs={}; profiles=[]
+    for record in registry.get("packs",[]):
+        key=short_pack_name(record["name"]); pack_dir=root/record["path"]; manifest_path=root/record["manifest"]
+        if not manifest_path.is_file(): raise CLIError(f"missing pack manifest: {record['manifest']}")
+        manifest=json.loads(manifest_path.read_text(encoding="utf-8")); rows=manifest.get("profiles",[]); backbone=frozenset(manifest.get("backbone_profiles",[])); orchestrator=manifest.get("orchestrator")
+        packs[key]=PackInfo(key,record["name"],pack_dir,record["namespace"],manifest_path,record.get("purpose",manifest.get("description","")),str(manifest.get("version","")),orchestrator,backbone,tuple(sorted({str(i.get("category","other")) for i in rows})),tuple(str(i["name"]) for i in rows))
+        for item in rows:
+            name=str(item["name"]); source=pack_dir/"profiles"/name; desc=str(item.get("description") or _yaml_scalar(source/"distribution.yaml","description"))
+            profiles.append(Profile(key,record["name"],name,str(item.get("display_name") or name),str(item.get("category") or "other"),desc,str(item.get("role") or ""),tuple(str(j) for j in item.get("jobs",[])),name==orchestrator,name in backbone,directory_size(source)))
+    return packs,profiles
 
-def load_catalog(root: Path = ROOT) -> tuple[dict[str, PackInfo], list[Profile]]:
-    pack_file = root / "packs.json"
-    if not pack_file.is_file():
-        raise CLIError(f"missing pack registry: {pack_file}")
-    registry = json.loads(pack_file.read_text(encoding="utf-8"))
+def load_recipe_catalog(root:Path=ROOT):
+    try: return recipe_catalog.load_recipes(root)
+    except recipe_catalog.RecipeError as exc: raise CLIError(str(exc)) from exc
 
-    packs: dict[str, PackInfo] = {}
-    profiles: list[Profile] = []
-    for record in registry.get("packs", []):
-        key = short_pack_name(record["name"])
-        pack_dir = root / record["path"]
-        manifest_path = root / record["manifest"]
-        if not manifest_path.is_file():
-            raise CLIError(f"missing pack manifest: {record['manifest']}")
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        manifest_profiles = manifest.get("profiles", [])
-        backbone = frozenset(manifest.get("backbone_profiles", []))
-        orchestrator = manifest.get("orchestrator")
-        categories = tuple(sorted({str(item.get("category", "other")) for item in manifest_profiles}))
-        profile_names = tuple(str(item["name"]) for item in manifest_profiles)
-        packs[key] = PackInfo(
-            key=key,
-            name=record["name"],
-            path=pack_dir,
-            namespace=record["namespace"],
-            manifest_path=manifest_path,
-            purpose=record.get("purpose", manifest.get("description", "")),
-            version=str(manifest.get("version", "")),
-            orchestrator=orchestrator,
-            backbone=backbone,
-            categories=categories,
-            profile_names=profile_names,
-        )
-        for item in manifest_profiles:
-            name = str(item["name"])
-            source = pack_dir / "profiles" / name
-            distribution = source / "distribution.yaml"
-            description = str(item.get("description") or _yaml_scalar(distribution, "description"))
-            role = str(item.get("role") or "")
-            jobs = tuple(str(job) for job in item.get("jobs", []))
-            profiles.append(
-                Profile(
-                    pack=key,
-                    pack_name=record["name"],
-                    name=name,
-                    display_name=str(item.get("display_name") or name),
-                    category=str(item.get("category") or "other"),
-                    description=description,
-                    role=role,
-                    jobs=jobs,
-                    orchestrator=name == orchestrator,
-                    backbone=name in backbone,
-                    source_bytes=directory_size(source),
-                )
-            )
-    return packs, profiles
+def tokenize(text:str)->set[str]: return set(TOKEN_RE.findall(text.lower()))
+def expanded_query(text:str)->set[str]:
+    tokens=tokenize(text); out=set(tokens)
+    for token in tokens: out.update(QUERY_EXPANSIONS.get(token,set()))
+    return out
 
+def _profile_score(profile:Profile,query:str,query_tokens:set[str]):
+    name_hits=sorted(query_tokens & tokenize(profile.name.replace("-"," ")+" "+profile.display_name)); cat_hits=sorted(query_tokens & tokenize(profile.category)); job_hits=sorted(query_tokens & tokenize(" ".join(profile.jobs))); detail_hits=sorted(query_tokens & tokenize(profile.description+" "+profile.role)); score=len(name_hits)*8+len(cat_hits)*5+len(job_hits)*5+len(detail_hits)*3; reasons=[]
+    if name_hits: reasons.append("profile: "+", ".join(name_hits[:3]))
+    if cat_hits: reasons.append("category: "+", ".join(cat_hits[:2]))
+    if job_hits: reasons.append("capability: "+", ".join(job_hits[:3]))
+    if detail_hits: reasons.append("description: "+", ".join(detail_hits[:3]))
+    raw=" ".join(query.lower().split())
+    if raw and len(raw)>=4 and raw in profile.searchable_text(): score+=14; reasons.insert(0,"exact phrase match")
+    pack_hits=sorted(tokenize(query)&PACK_HINTS.get(profile.pack,set()))
+    if pack_hits: score+=min(8,2*len(pack_hits)); reasons.append(f"{PACK_DISPLAY[profile.pack]} intent")
+    if profile.orchestrator: score += 9 if tokenize(query)&COORDINATION_TERMS else -4
+    if profile.backbone and not profile.orchestrator: score+=1
+    return score,reasons
 
-def tokenize(text: str) -> set[str]:
-    return set(TOKEN_RE.findall(text.lower()))
+def recommend_profiles(profiles:Iterable[Profile],query:str,*,limit:int=6,pack_filter:set[str]|None=None):
+    if not query.strip(): raise CLIError("recommendation query cannot be empty")
+    if limit<1: raise CLIError("--limit must be at least 1")
+    q=expanded_query(query); ranked=[]
+    for p in profiles:
+        if pack_filter and p.pack not in pack_filter: continue
+        score,reasons=_profile_score(p,query,q)
+        if score>0: ranked.append((p,score,reasons))
+    ranked.sort(key=lambda i:(-i[1],i[0].orchestrator,i[0].pack,i[0].category,i[0].name)); return ranked[:limit]
 
+def recommend_recipes(recipes,query,*,limit=5,pack_filter=None):
+    try: return recipe_catalog.recommend_recipes(recipes,query,expanded_query=expanded_query,tokenize=tokenize,pack_hints=PACK_HINTS,pack_display=PACK_DISPLAY,limit=limit,pack_filter=pack_filter)
+    except recipe_catalog.RecipeError as exc: raise CLIError(str(exc)) from exc
 
-def expanded_query(text: str) -> set[str]:
-    tokens = tokenize(text)
-    expanded = set(tokens)
-    for token in tokens:
-        expanded.update(QUERY_EXPANSIONS.get(token, set()))
-    return expanded
+def recommend_goal(profiles,recipes,query,*,limit=6,pack_filter=None):
+    rr=recommend_recipes(recipes.values(),query,limit=min(5,max(1,limit)),pack_filter=pack_filter); return rr,recipe_catalog.confident_recipe_match(rr),recommend_profiles(profiles,query,limit=limit,pack_filter=pack_filter)
 
+def format_bytes(value:int)->str:
+    amount=float(value); unit="B"
+    for unit in ["B","KiB","MiB","GiB"]:
+        if amount<1024 or unit=="GiB": break
+        amount/=1024
+    return f"{int(amount)} {unit}" if unit=="B" else f"{amount:.1f} {unit}"
 
-def _profile_score(profile: Profile, query: str, query_tokens: set[str]) -> tuple[int, list[str]]:
-    name_tokens = tokenize(profile.name.replace("-", " ") + " " + profile.display_name)
-    category_tokens = tokenize(profile.category)
-    job_tokens = tokenize(" ".join(profile.jobs))
-    detail_tokens = tokenize(profile.description + " " + profile.role)
+def selected_stats(selected,all_profiles):
+    s=list(selected); a=list(all_profiles); sb=sum(p.source_bytes for p in s); tb=sum(p.source_bytes for p in a); by={}
+    for p in s: by[p.pack]=by.get(p.pack,0)+1
+    return {"selected_profiles":len(s),"available_profiles":len(a),"skipped_profiles":max(0,len(a)-len(s)),"estimated_source_bytes":sb,"estimated_source_bytes_skipped":max(0,tb-sb),"by_pack":by}
 
-    score = 0
-    reasons: list[str] = []
+def filter_packs(values): return None if not values else {normalize_pack(v) for v in values}
 
-    name_hits = sorted(query_tokens & name_tokens)
-    category_hits = sorted(query_tokens & category_tokens)
-    job_hits = sorted(query_tokens & job_tokens)
-    detail_hits = sorted(query_tokens & detail_tokens)
-
-    score += len(name_hits) * 8
-    score += len(category_hits) * 5
-    score += len(job_hits) * 5
-    score += len(detail_hits) * 3
-
-    if name_hits:
-        reasons.append("profile: " + ", ".join(name_hits[:3]))
-    if category_hits:
-        reasons.append("category: " + ", ".join(category_hits[:2]))
-    if job_hits:
-        reasons.append("capability: " + ", ".join(job_hits[:3]))
-    if detail_hits:
-        reasons.append("description: " + ", ".join(detail_hits[:3]))
-
-    raw_query = " ".join(query.lower().split())
-    searchable = profile.searchable_text()
-    if raw_query and len(raw_query) >= 4 and raw_query in searchable:
-        score += 14
-        reasons.insert(0, "exact phrase match")
-
-    pack_hits = sorted(tokenize(query) & PACK_HINTS.get(profile.pack, set()))
-    if pack_hits:
-        score += min(8, 2 * len(pack_hits))
-        reasons.append(f"{PACK_DISPLAY[profile.pack]} intent")
-
-    asks_for_coordination = bool(tokenize(query) & COORDINATION_TERMS)
-    if profile.orchestrator:
-        score += 9 if asks_for_coordination else -4
-    if profile.backbone and not profile.orchestrator:
-        score += 1
-
-    return score, reasons
-
-
-def recommend_profiles(
-    profiles: Iterable[Profile],
-    query: str,
-    *,
-    limit: int = 6,
-    pack_filter: set[str] | None = None,
-) -> list[tuple[Profile, int, list[str]]]:
-    if not query.strip():
-        raise CLIError("recommendation query cannot be empty")
-    if limit < 1:
-        raise CLIError("--limit must be at least 1")
-    query_tokens = expanded_query(query)
-    ranked: list[tuple[Profile, int, list[str]]] = []
-    for profile in profiles:
-        if pack_filter and profile.pack not in pack_filter:
-            continue
-        score, reasons = _profile_score(profile, query, query_tokens)
-        if score > 0:
-            ranked.append((profile, score, reasons))
-    ranked.sort(
-        key=lambda item: (
-            -item[1],
-            item[0].orchestrator,
-            item[0].pack,
-            item[0].category,
-            item[0].name,
-        )
-    )
-    return ranked[:limit]
-
-
-def format_bytes(value: int) -> str:
-    amount = float(value)
-    units = ["B", "KiB", "MiB", "GiB"]
-    unit = units[0]
-    for unit in units:
-        if amount < 1024.0 or unit == units[-1]:
-            break
-        amount /= 1024.0
-    if unit == "B":
-        return f"{int(amount)} {unit}"
-    return f"{amount:.1f} {unit}"
-
-
-def selected_stats(selected: Iterable[Profile], all_profiles: Iterable[Profile]) -> dict:
-    selected_list = list(selected)
-    all_list = list(all_profiles)
-    selected_bytes = sum(profile.source_bytes for profile in selected_list)
-    total_bytes = sum(profile.source_bytes for profile in all_list)
-    by_pack: dict[str, int] = {}
-    for profile in selected_list:
-        by_pack[profile.pack] = by_pack.get(profile.pack, 0) + 1
-    return {
-        "selected_profiles": len(selected_list),
-        "available_profiles": len(all_list),
-        "skipped_profiles": max(0, len(all_list) - len(selected_list)),
-        "estimated_source_bytes": selected_bytes,
-        "estimated_source_bytes_skipped": max(0, total_bytes - selected_bytes),
-        "by_pack": by_pack,
-    }
-
-
-def filter_packs(values: list[str] | None) -> set[str] | None:
-    if not values:
-        return None
-    return {normalize_pack(value) for value in values}
-
-
-def resolve_selection(
-    profiles: list[Profile],
-    *,
-    explicit_names: list[str] | None,
-    category_specs: list[str] | None,
-    select_all: bool,
-    pack_filter: set[str] | None,
-) -> list[Profile]:
-    by_name = {profile.name: profile for profile in profiles}
-    chosen: dict[str, Profile] = {}
-
+def resolve_selection(profiles,*,explicit_names,category_specs,select_all,pack_filter):
+    by_name={p.name:p for p in profiles}; chosen={}
     if select_all:
-        for profile in profiles:
-            if not pack_filter or profile.pack in pack_filter:
-                chosen[profile.name] = profile
-
+        for p in profiles:
+            if not pack_filter or p.pack in pack_filter: chosen[p.name]=p
     for name in explicit_names or []:
         for part in name.split(","):
-            item = part.strip()
-            if not item:
-                continue
-            profile = by_name.get(item)
-            if not profile:
-                raise CLIError(f"unknown profile: {item}")
-            if pack_filter and profile.pack not in pack_filter:
-                raise CLIError(f"profile {item} is outside the requested --pack filter")
-            chosen[item] = profile
-
+            item=part.strip()
+            if not item: continue
+            p=by_name.get(item)
+            if not p: raise CLIError(f"unknown profile: {item}")
+            if pack_filter and p.pack not in pack_filter: raise CLIError(f"profile {item} is outside the requested --pack filter")
+            chosen[item]=p
     for spec in category_specs or []:
-        if ":" not in spec:
-            raise CLIError("categories must use PACK:CATEGORY, for example agency:engineering")
-        pack_value, category = spec.split(":", 1)
-        pack = normalize_pack(pack_value)
-        if pack_filter and pack not in pack_filter:
-            raise CLIError(f"category {spec} is outside the requested --pack filter")
-        matches = [profile for profile in profiles if profile.pack == pack and profile.category == category]
-        if not matches:
-            available = sorted({profile.category for profile in profiles if profile.pack == pack})
-            raise CLIError(
-                f"unknown category '{category}' for {pack}. Available: {', '.join(available)}"
-            )
-        for profile in matches:
-            chosen[profile.name] = profile
+        if ":" not in spec: raise CLIError("categories must use PACK:CATEGORY, for example agency:engineering")
+        pv,cat=spec.split(":",1); pack=normalize_pack(pv)
+        if pack_filter and pack not in pack_filter: raise CLIError(f"category {spec} is outside the requested --pack filter")
+        matches=[p for p in profiles if p.pack==pack and p.category==cat]
+        if not matches: raise CLIError(f"unknown category '{cat}' for {pack}. Available: {', '.join(sorted({p.category for p in profiles if p.pack==pack}))}")
+        for p in matches: chosen[p.name]=p
+    return sorted(chosen.values(),key=lambda p:(p.pack,p.name))
 
-    return sorted(chosen.values(), key=lambda profile: (profile.pack, profile.name))
+def resolve_recipe_selection(recipe,tier,profiles,*,pack_filter=None):
+    if pack_filter and recipe.pack not in pack_filter: raise CLIError(f"recipe {recipe.id} is outside the requested --pack filter")
+    try: return recipe_catalog.resolve_recipe_profiles(recipe,tier,profiles)
+    except recipe_catalog.RecipeError as exc: raise CLIError(str(exc)) from exc
 
+def pack_installer(pack):
+    path=pack.path/"install.py"
+    if not path.is_file(): raise CLIError(f"missing installer for {pack.name}: {path}")
+    return path
 
-def pack_installer(pack: PackInfo) -> Path:
-    installer = pack.path / "install.py"
-    if not installer.is_file():
-        raise CLIError(f"missing installer for {pack.name}: {installer}")
-    return installer
-
-
-def install_selected(
-    selected: list[Profile],
-    packs: dict[str, PackInfo],
-    *,
-    force: bool,
-    json_mode: bool,
-) -> tuple[int, list[dict]]:
-    grouped: dict[str, list[Profile]] = {}
-    for profile in selected:
-        grouped.setdefault(profile.pack, []).append(profile)
-
-    results: list[dict] = []
-    for pack_key in ("agency", "council", "academy"):
-        members = grouped.get(pack_key)
-        if not members:
-            continue
-        pack = packs[pack_key]
-        command = [sys.executable, str(pack_installer(pack)), *[p.name for p in members]]
-        if force:
-            command.append("--force")
-        if not json_mode:
-            print(f"\n==> {PACK_DISPLAY[pack_key]}: {len(members)} profile(s)")
-        completed = subprocess.run(
-            command,
-            text=True,
-            capture_output=json_mode,
-            check=False,
-        )
-        result = {
-            "pack": pack_key,
-            "profiles": [p.name for p in members],
-            "returncode": completed.returncode,
-        }
-        if json_mode:
-            result["stdout"] = completed.stdout
-            result["stderr"] = completed.stderr
+def install_selected(selected,packs,*,force,json_mode):
+    grouped={}
+    for p in selected: grouped.setdefault(p.pack,[]).append(p)
+    results=[]
+    for key in ("agency","council","academy"):
+        members=grouped.get(key)
+        if not members: continue
+        cmd=[sys.executable,str(pack_installer(packs[key])),*[p.name for p in members]]
+        if force: cmd.append("--force")
+        if not json_mode: print(f"\n==> {PACK_DISPLAY[key]}: {len(members)} profile(s)")
+        c=subprocess.run(cmd,text=True,capture_output=json_mode,check=False); result={"pack":key,"profiles":[p.name for p in members],"returncode":c.returncode}
+        if json_mode: result.update(stdout=c.stdout,stderr=c.stderr)
         results.append(result)
-        if completed.returncode:
-            return completed.returncode, results
-    return 0, results
+        if c.returncode: return c.returncode,results
+    return 0,results
 
+def print_pack_list(packs,profiles):
+    counts={k:0 for k in packs}
+    for p in profiles: counts[p.pack]=counts.get(p.pack,0)+1
+    for k in ("agency","council","academy"):
+        if k in packs: print(f"{k:<8} {packs[k].namespace:<11} {counts[k]:>3} profiles  {packs[k].purpose}")
+def print_catalog(profiles):
+    cur=None
+    for p in sorted(profiles,key=lambda x:(x.pack,x.category,x.name)):
+        marker=(p.pack,p.category)
+        if marker!=cur: print(f"\n{PACK_DISPLAY[p.pack]} / {p.category}"); cur=marker
+        print(f"  {p.name:<42} {p.display_name}")
+def print_recipe_list(recipes,*,profiles=None):
+    cur=None
+    for r in sorted(recipes,key=lambda x:(x.pack,x.id)):
+        if r.pack!=cur: print(f"\n{PACK_DISPLAY[r.pack]}"); cur=r.pack
+        counts="/".join(str(len(r.tiers[t])) for t in recipe_catalog.TIER_ORDER); print(f"  {r.id:<28} {r.display_name}  [{counts} profiles]\n    {r.description}")
+def _prompt(prompt):
+    try: return input(prompt).strip()
+    except (EOFError,KeyboardInterrupt) as exc: print(); raise CLIError("selection cancelled") from exc
 
-def print_pack_list(packs: dict[str, PackInfo], profiles: list[Profile]) -> None:
-    counts = {key: 0 for key in packs}
-    for profile in profiles:
-        counts[profile.pack] = counts.get(profile.pack, 0) + 1
-    for key in ("agency", "council", "academy"):
-        if key not in packs:
-            continue
-        pack = packs[key]
-        print(f"{key:<8} {pack.namespace:<11} {counts[key]:>3} profiles  {pack.purpose}")
-
-
-def print_catalog(profiles: Iterable[Profile]) -> None:
-    current: tuple[str, str] | None = None
-    for profile in sorted(profiles, key=lambda p: (p.pack, p.category, p.name)):
-        marker = (profile.pack, profile.category)
-        if marker != current:
-            print(f"\n{PACK_DISPLAY[profile.pack]} / {profile.category}")
-            current = marker
-        print(f"  {profile.name:<42} {profile.display_name}")
-
-
-def _prompt(prompt: str) -> str:
-    try:
-        return input(prompt).strip()
-    except (EOFError, KeyboardInterrupt) as exc:
-        print()
-        raise CLIError("selection cancelled") from exc
-
-
-def _parse_indices(value: str, count: int, *, blank_means_all: bool = False) -> list[int]:
-    value = value.strip().lower()
-    if not value:
-        return list(range(count)) if blank_means_all else []
-    if value in {"all", "a"}:
-        return list(range(count))
-    if value in {"none", "n"}:
-        return []
-    picked: set[int] = set()
+def _parse_indices(value,count,*,blank_means_all=False):
+    value=value.strip().lower()
+    if not value: return list(range(count)) if blank_means_all else []
+    if value in {"all","a"}: return list(range(count))
+    if value in {"none","n"}: return []
+    picked=set()
     for chunk in value.split(","):
-        chunk = chunk.strip()
-        if not chunk:
-            continue
+        chunk=chunk.strip()
+        if not chunk: continue
         if "-" in chunk:
-            left, right = chunk.split("-", 1)
-            try:
-                start, end = int(left), int(right)
-            except ValueError as exc:
-                raise CLIError(f"invalid selection: {chunk}") from exc
-            if start > end:
-                start, end = end, start
-            numbers = range(start, end + 1)
+            l,r=chunk.split("-",1)
+            try: start,end=int(l),int(r)
+            except ValueError as exc: raise CLIError(f"invalid selection: {chunk}") from exc
+            if start>end: start,end=end,start
+            nums=range(start,end+1)
         else:
-            try:
-                numbers = [int(chunk)]
-            except ValueError as exc:
-                raise CLIError(f"invalid selection: {chunk}") from exc
-        for number in numbers:
-            if number < 1 or number > count:
-                raise CLIError(f"selection {number} is outside 1-{count}")
-            picked.add(number - 1)
+            try: nums=[int(chunk)]
+            except ValueError as exc: raise CLIError(f"invalid selection: {chunk}") from exc
+        for n in nums:
+            if n<1 or n>count: raise CLIError(f"selection {n} is outside 1-{count}")
+            picked.add(n-1)
     return sorted(picked)
-
-
-def _choose_profiles(items: list[Profile], *, blank_means_all: bool = False) -> list[Profile]:
-    for index, profile in enumerate(items, 1):
-        description = profile.description or profile.role
-        if len(description) > 96:
-            description = description[:93].rstrip() + "..."
-        print(f"  {index:>2}. {profile.display_name}  [{profile.name}]")
-        if description:
-            print(f"      {description}")
-    suffix = " [Enter = all]" if blank_means_all else ""
+def _choose_profiles(items,*,blank_means_all=False):
+    for i,p in enumerate(items,1):
+        d=p.description or p.role; d=d if len(d)<=96 else d[:93].rstrip()+"..."; print(f"  {i:>2}. {p.display_name}  [{p.name}]"); print(f"      {d}") if d else None
+    suffix=" [Enter = all]" if blank_means_all else ""
     while True:
-        value = _prompt(f"Select numbers (for example 1,3-5 or all){suffix}: ")
-        try:
-            indexes = _parse_indices(value, len(items), blank_means_all=blank_means_all)
-            return [items[index] for index in indexes]
-        except CLIError as exc:
-            print(f"  {exc}")
-
-
-def wizard_recommend(profiles: list[Profile]) -> list[Profile]:
-    print("\nTell me what you want Hermes to help with.")
-    print("Examples: 'build web apps', 'get my finances organized', 'learn cybersecurity'.")
+        try: return [items[i] for i in _parse_indices(_prompt(f"Select numbers (for example 1,3-5 or all){suffix}: "),len(items),blank_means_all=blank_means_all)]
+        except CLIError as exc: print(f"  {exc}")
+def _choose_recipe_tier(recipe,profiles):
+    labels={"minimal":"smallest coherent formation","recommended":"default balance of expertise and review","expanded":"broader coverage for larger or higher-risk work"}; print(f"\n{recipe.display_name} tiers:")
+    for i,t in enumerate(recipe_catalog.TIER_ORDER,1): print(f"  {i}. {t:<11} {len(recipe.tiers[t]):>2} profiles - {labels[t]}")
     while True:
-        query = _prompt("What do you need? ")
-        try:
-            ranked = recommend_profiles(profiles, query, limit=6)
-        except CLIError as exc:
-            print(f"  {exc}")
-            continue
-        if not ranked:
-            print("I couldn't find a confident match. Try a few more concrete words, or browse instead.")
-            continue
-        print("\nSmallest useful matches I found:")
-        for index, (profile, score, reasons) in enumerate(ranked, 1):
-            why = "; ".join(reasons[:2]) or "catalog match"
-            print(f"  {index}. {profile.display_name} ({PACK_DISPLAY[profile.pack]})")
-            print(f"     {profile.name} · {why} · score {score}")
-        chosen = _choose_profiles([item[0] for item in ranked], blank_means_all=True)
-        if chosen:
-            return chosen
-        print("Nothing selected. Try another description or return to the main menu.")
-        return []
-
-
-def wizard_browse(packs: dict[str, PackInfo], profiles: list[Profile]) -> list[Profile]:
-    pack_keys = [key for key in ("agency", "council", "academy") if key in packs]
-    print("\nChoose a pack:")
-    for index, key in enumerate(pack_keys, 1):
-        count = sum(1 for profile in profiles if profile.pack == key)
-        print(f"  {index}. {PACK_DISPLAY[key]} ({count} profiles) - {packs[key].purpose}")
+        value=_prompt("Choose tier 1-3 [2]: ") or "2"
+        try: idx=_parse_indices(value,3)
+        except CLIError as exc: print(f"  {exc}"); continue
+        if len(idx)!=1: print("  Choose exactly one tier."); continue
+        tier=recipe_catalog.TIER_ORDER[idx[0]]; selected=resolve_recipe_selection(recipe,tier,profiles); print(f"\n{tier.title()} recipe plan:")
+        for p in selected: print(f"  - {p.display_name} ({p.name})")
+        return tier,selected
+def wizard_recommend(profiles,recipes):
+    print("\nTell me what you want Hermes to help with.\nExamples: 'build a web app', 'get my finances organized', 'learn cybersecurity'.")
     while True:
-        value = _prompt("Pack number: ")
-        try:
-            indices = _parse_indices(value, len(pack_keys))
-        except CLIError as exc:
-            print(f"  {exc}")
-            continue
-        if len(indices) != 1:
-            print("  Choose exactly one pack.")
-            continue
-        pack = pack_keys[indices[0]]
-        break
-
-    categories = list(packs[pack].categories)
-    print(f"\n{PACK_DISPLAY[pack]} categories:")
-    for index, category in enumerate(categories, 1):
-        count = sum(1 for profile in profiles if profile.pack == pack and profile.category == category)
-        print(f"  {index}. {category} ({count})")
+        query=_prompt("What do you need? ")
+        try: _,confident,ranked=recommend_goal(profiles,recipes,query,limit=6)
+        except CLIError as exc: print(f"  {exc}"); continue
+        if confident:
+            r,score,reasons=confident; print(f"\nThis maps cleanly to a validated Team Recipe:\n  {r.display_name} [{r.id}]\n  {r.description}\n  Match: {'; '.join(reasons[:2]) or r.description} · score {score}")
+            if _prompt("Use this team recipe? [Y/n]: ").lower() not in {"n","no"}: return _choose_recipe_tier(r,profiles)[1]
+            print("\nOkay - showing individual profile matches instead.")
+        if not ranked: print("I couldn't find a confident match. Try a few more concrete words, or browse instead."); continue
+        print("\nSmallest useful individual matches I found:")
+        for i,(p,score,reasons) in enumerate(ranked,1): print(f"  {i}. {p.display_name} ({PACK_DISPLAY[p.pack]})\n     {p.name} · {'; '.join(reasons[:2]) or 'catalog match'} · score {score}")
+        chosen=_choose_profiles([i[0] for i in ranked],blank_means_all=True)
+        return chosen if chosen else []
+def wizard_browse_recipes(recipes,profiles):
+    ordered=sorted(recipes.values(),key=lambda r:(r.pack,r.id)); print("\nTeam Recipes:")
+    for i,r in enumerate(ordered,1): print(f"  {i:>2}. {r.display_name} ({PACK_DISPLAY[r.pack]})\n      {r.id} - {r.description}")
+    while True:
+        try: idx=_parse_indices(_prompt("Recipe number: "),len(ordered))
+        except CLIError as exc: print(f"  {exc}"); continue
+        if len(idx)!=1: print("  Choose exactly one recipe."); continue
+        return _choose_recipe_tier(ordered[idx[0]],profiles)[1]
+def wizard_browse(packs,profiles):
+    keys=[k for k in ("agency","council","academy") if k in packs]; print("\nChoose a pack:")
+    for i,k in enumerate(keys,1): print(f"  {i}. {PACK_DISPLAY[k]} ({sum(1 for p in profiles if p.pack==k)} profiles) - {packs[k].purpose}")
+    while True:
+        try: idx=_parse_indices(_prompt("Pack number: "),len(keys))
+        except CLIError as exc: print(f"  {exc}"); continue
+        if len(idx)==1: pack=keys[idx[0]]; break
+        print("  Choose exactly one pack.")
+    cats=list(packs[pack].categories); print(f"\n{PACK_DISPLAY[pack]} categories:")
+    for i,c in enumerate(cats,1): print(f"  {i}. {c} ({sum(1 for p in profiles if p.pack==pack and p.category==c)})")
     print("  all. Show the whole pack")
     while True:
-        value = _prompt("Category number or all: ").lower()
-        if value in {"all", "a"}:
-            candidates = [profile for profile in profiles if profile.pack == pack]
-            break
-        try:
-            indices = _parse_indices(value, len(categories))
-        except CLIError as exc:
-            print(f"  {exc}")
-            continue
-        if len(indices) != 1:
-            print("  Choose exactly one category.")
-            continue
-        category = categories[indices[0]]
-        candidates = [
-            profile for profile in profiles if profile.pack == pack and profile.category == category
-        ]
-        break
-    return _choose_profiles(sorted(candidates, key=lambda p: p.name))
-
-
-def wizard_direct(profiles: list[Profile]) -> list[Profile]:
-    query = _prompt("\nSearch profile names/descriptions: ")
-    ranked = recommend_profiles(profiles, query, limit=20)
-    if not ranked:
-        print("No matching profiles found.")
-        return []
-    return _choose_profiles([item[0] for item in ranked])
-
-
-def run_wizard(packs: dict[str, PackInfo], profiles: list[Profile], *, force: bool) -> int:
-    if not (sys.stdin.isatty() and sys.stdout.isatty()):
-        raise CLIError("the interactive wizard requires a terminal; agents should use --agent-help")
-
-    print("\nHermes Profile Packs 🪽")
-    print("Pick only what helps. You can always add more later.")
-    print(f"Catalog: {len(profiles)} profiles across {len(packs)} packs.\n")
-    print("  1. Recommend a small set for me")
-    print("  2. Browse packs and categories")
-    print("  3. Search profiles directly")
-    print("  4. Install everything")
-    print("  5. Exit")
-
-    selected: list[Profile]
+        v=_prompt("Category number or all: ").lower()
+        if v in {"all","a"}: candidates=[p for p in profiles if p.pack==pack]; break
+        try: idx=_parse_indices(v,len(cats))
+        except CLIError as exc: print(f"  {exc}"); continue
+        if len(idx)!=1: print("  Choose exactly one category."); continue
+        candidates=[p for p in profiles if p.pack==pack and p.category==cats[idx[0]]]; break
+    return _choose_profiles(sorted(candidates,key=lambda p:p.name))
+def wizard_direct(profiles):
+    ranked=recommend_profiles(profiles,_prompt("\nSearch profile names/descriptions: "),limit=20)
+    return _choose_profiles([i[0] for i in ranked]) if ranked else []
+def run_wizard(packs,profiles,recipes,*,force):
+    if not (sys.stdin.isatty() and sys.stdout.isatty()): raise CLIError("the interactive wizard requires a terminal; agents should use --agent-help")
+    print(f"\nHermes Profile Packs 🪽\nPick only what helps. You can always add more later.\nCatalog: {len(profiles)} profiles, {len(recipes)} team recipes, {len(packs)} packs.\n\n  1. Recommend a small team for me\n  2. Browse team recipes\n  3. Browse packs and categories\n  4. Search profiles directly\n  5. Install everything\n  6. Exit")
     while True:
-        choice = _prompt("Choose 1-5 [1]: ") or "1"
-        if choice == "1":
-            selected = wizard_recommend(profiles)
-            if not selected:
-                continue
-            break
-        if choice == "2":
-            selected = wizard_browse(packs, profiles)
-            if not selected:
-                continue
-            break
-        if choice == "3":
-            selected = wizard_direct(profiles)
-            if not selected:
-                continue
-            break
-        if choice == "4":
-            selected = list(profiles)
-            break
-        if choice == "5":
-            print("Nothing installed.")
-            return 0
-        print("Choose 1, 2, 3, 4, or 5.")
-
-    stats = selected_stats(selected, profiles)
-    print("\nInstall plan")
-    for pack in ("agency", "council", "academy"):
-        names = [p for p in selected if p.pack == pack]
-        if names:
-            print(f"  {PACK_DISPLAY[pack]}: {len(names)}")
-            for profile in names:
-                print(f"    - {profile.display_name} ({profile.name})")
-    print(
-        f"\nSelected {stats['selected_profiles']} of {stats['available_profiles']} profiles "
-        f"(~{format_bytes(stats['estimated_source_bytes'])} source payload)."
-    )
-    if stats["skipped_profiles"]:
-        print(
-            f"Skipping {stats['skipped_profiles']} profiles "
-            f"(~{format_bytes(stats['estimated_source_bytes_skipped'])} of catalog payload)."
-        )
-    answer = _prompt("Install this selection? [y/N]: ").lower()
-    if answer not in {"y", "yes"}:
-        print("Nothing installed.")
-        return 0
-    code, _ = install_selected(selected, packs, force=force, json_mode=False)
-    return code
-
-
-def legacy_delegate(argv: list[str]) -> int | None:
-    if not argv or argv[0].startswith("-"):
-        return None
+        choice=_prompt("Choose 1-6 [1]: ") or "1"
+        if choice=="1": selected=wizard_recommend(profiles,recipes)
+        elif choice=="2": selected=wizard_browse_recipes(recipes,profiles)
+        elif choice=="3": selected=wizard_browse(packs,profiles)
+        elif choice=="4": selected=wizard_direct(profiles)
+        elif choice=="5": selected=list(profiles)
+        elif choice=="6": print("Nothing installed."); return 0
+        else: print("Choose 1, 2, 3, 4, 5, or 6."); continue
+        if selected: break
+    stats=selected_stats(selected,profiles); print("\nInstall plan")
+    for pack in ("agency","council","academy"):
+        members=[p for p in selected if p.pack==pack]
+        if members:
+            print(f"  {PACK_DISPLAY[pack]}: {len(members)}")
+            for p in members: print(f"    - {p.display_name} ({p.name})")
+    print(f"\nSelected {stats['selected_profiles']} of {stats['available_profiles']} profiles (~{format_bytes(stats['estimated_source_bytes'])} source payload).")
+    if stats['skipped_profiles']: print(f"Skipping {stats['skipped_profiles']} profiles (~{format_bytes(stats['estimated_source_bytes_skipped'])} of catalog payload).")
+    if _prompt("Install this selection? [y/N]: ").lower() not in {"y","yes"}: print("Nothing installed."); return 0
+    return install_selected(selected,packs,force=force,json_mode=False)[0]
+def legacy_delegate(argv):
+    if not argv or argv[0].startswith("-"): return None
+    try: key=normalize_pack(argv[0])
+    except CLIError: return None
+    reg=json.loads(PACK_FILE.read_text(encoding="utf-8")); rec=next((i for i in reg.get("packs",[]) if short_pack_name(i["name"])==key),None)
+    if not rec: raise CLIError(f"pack is registered but unavailable: {key}")
+    return subprocess.run([sys.executable,str(ROOT/rec["path"]/"install.py"),*argv[1:]],check=False).returncode
+def build_parser():
+    p=argparse.ArgumentParser(description="Choose only the Hermes profiles or validated team recipe you need.",epilog="Legacy pack commands still work: python install.py council --list. Run with no arguments in a terminal to launch the wizard.")
+    p.add_argument("--wizard",action="store_true"); p.add_argument("--list-packs",action="store_true"); p.add_argument("--catalog",action="store_true"); p.add_argument("--list-recipes",action="store_true"); p.add_argument("--recommend",metavar="TEXT"); p.add_argument("--agent-help",action="store_true"); p.add_argument("--pack",action="append"); p.add_argument("--recipe"); p.add_argument("--tier",choices=recipe_catalog.TIER_ORDER); p.add_argument("--profiles",nargs="+"); p.add_argument("--category",action="append",metavar="PACK:CATEGORY"); p.add_argument("--all",action="store_true"); p.add_argument("--limit",type=int,default=6); p.add_argument("--dry-run",action="store_true"); p.add_argument("--force",action="store_true"); p.add_argument("--yes",action="store_true"); p.add_argument("--json",action="store_true"); return p
+def agent_help_payload(): return {"interactive":"python install.py","catalog":"python install.py --catalog --json","recipes":"python install.py --list-recipes --json","recommend":"python install.py --recommend 'build a web app' --json","recipe_dry_run":"python install.py --recipe software-delivery --tier minimal --dry-run --json","install_recipe":"python install.py --recipe software-delivery --tier recommended --yes --json","dry_run":"python install.py --profiles agency-backend-engineer agency-frontend-engineer --dry-run --json","install_profiles":"python install.py --profiles agency-backend-engineer agency-frontend-engineer --yes --json","install_category":"python install.py --category council:growth --yes --json","install_everything":"python install.py --all --yes --json","rules":["--catalog, --list-recipes, and --recommend are read-only","--recommend preserves individual profile results and adds a recipe_match only when confidence is high","--json never prompts","writes require --yes unless using the interactive wizard","use --dry-run to inspect an exact profile or recipe plan","legacy pack-first commands remain supported"]}
+def emit_json(payload): print(json.dumps(payload,indent=2,sort_keys=True))
+def _recipe_summary(ranked,confident):
+    match=None
+    if confident:
+        r,score,reasons=confident; match={"recipe":r.id,"display_name":r.display_name,"pack":r.pack,"score":score,"reasons":reasons,"default_tier":recipe_catalog.DEFAULT_TIER,"profiles":list(r.tiers[recipe_catalog.DEFAULT_TIER])}
+    return match,[{"recipe":r.id,"display_name":r.display_name,"pack":r.pack,"score":score,"reasons":reasons,"recommended_profiles":list(r.tiers[recipe_catalog.DEFAULT_TIER])} for r,score,reasons in ranked]
+def main(argv=None):
+    argv=list(sys.argv[1:] if argv is None else argv); legacy=legacy_delegate(argv)
+    if legacy is not None: return legacy
+    args=build_parser().parse_args(argv)
     try:
-        key = normalize_pack(argv[0])
-    except CLIError:
-        return None
-    registry = json.loads(PACK_FILE.read_text(encoding="utf-8"))
-    record = next(
-        (item for item in registry.get("packs", []) if short_pack_name(item["name"]) == key),
-        None,
-    )
-    if not record:
-        raise CLIError(f"pack is registered but unavailable: {key}")
-    installer = ROOT / record["path"] / "install.py"
-    return subprocess.run([sys.executable, str(installer), *argv[1:]], check=False).returncode
-
-
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Choose only the Hermes profiles you need, or install every pack.",
-        epilog=(
-            "Legacy pack commands still work: python install.py council --list. "
-            "Run with no arguments in a terminal to launch the wizard."
-        ),
-    )
-    parser.add_argument("--wizard", action="store_true", help="Launch the interactive selector.")
-    parser.add_argument("--list-packs", action="store_true", help="List registered packs and exit.")
-    parser.add_argument("--catalog", action="store_true", help="List the profile catalog and exit.")
-    parser.add_argument("--recommend", metavar="TEXT", help="Recommend a small profile set for a goal and exit.")
-    parser.add_argument("--agent-help", action="store_true", help="Print the non-interactive agent contract and exit.")
-    parser.add_argument("--pack", action="append", help="Filter by pack; repeatable (agency, council, academy).")
-    parser.add_argument("--profiles", nargs="+", help="Install explicit profile names. Comma-separated names also work.")
-    parser.add_argument(
-        "--category",
-        action="append",
-        metavar="PACK:CATEGORY",
-        help="Install a category, for example agency:engineering. Repeatable.",
-    )
-    parser.add_argument("--all", action="store_true", help="Install all profiles, optionally limited by --pack.")
-    parser.add_argument("--limit", type=int, default=6, help="Maximum recommendations (default: 6).")
-    parser.add_argument("--dry-run", action="store_true", help="Print the install plan without changing Hermes.")
-    parser.add_argument("--force", action="store_true", help="Re-apply selected distributions over existing profiles.")
-    parser.add_argument("--yes", action="store_true", help="Approve a non-interactive install plan.")
-    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON. Never prompts.")
-    return parser
-
-
-def agent_help_payload() -> dict:
-    return {
-        "interactive": "python install.py",
-        "catalog": "python install.py --catalog --json",
-        "recommend": "python install.py --recommend 'build a web app' --json",
-        "dry_run": "python install.py --profiles agency-backend-engineer agency-frontend-engineer --dry-run --json",
-        "install_profiles": "python install.py --profiles agency-backend-engineer agency-frontend-engineer --yes --json",
-        "install_category": "python install.py --category council:growth --yes --json",
-        "install_everything": "python install.py --all --yes --json",
-        "rules": [
-            "--catalog and --recommend are read-only",
-            "--json never prompts",
-            "writes require --yes unless using the interactive wizard",
-            "use --dry-run to inspect an exact install plan",
-            "legacy pack-first commands remain supported",
-        ],
-    }
-
-
-def emit_json(payload: dict) -> None:
-    print(json.dumps(payload, indent=2, sort_keys=True))
-
-
-def main(argv: list[str] | None = None) -> int:
-    argv = list(sys.argv[1:] if argv is None else argv)
-
-    legacy = legacy_delegate(argv)
-    if legacy is not None:
-        return legacy
-
-    parser = build_parser()
-    args = parser.parse_args(argv)
-
-    try:
-        packs, profiles = load_catalog()
-        pack_filter = filter_packs(args.pack)
-
-        if not argv:
-            return run_wizard(packs, profiles, force=False)
+        packs,profiles=load_catalog(); recipes=load_recipe_catalog(); pf=filter_packs(args.pack)
+        if not argv: return run_wizard(packs,profiles,recipes,force=False)
         if args.wizard:
-            if args.json:
-                raise CLIError("--wizard cannot be combined with --json")
-            return run_wizard(packs, profiles, force=args.force)
-
-        read_modes = sum(bool(value) for value in [args.list_packs, args.catalog, args.recommend, args.agent_help])
-        if read_modes > 1:
-            raise CLIError("choose only one of --list-packs, --catalog, --recommend, or --agent-help")
-        if read_modes and (args.profiles or args.category or args.all or args.dry_run or args.yes):
-            raise CLIError("read-only catalog/recommend modes cannot be combined with install-selection flags")
-
-        filtered_profiles = [
-            profile for profile in profiles if not pack_filter or profile.pack in pack_filter
-        ]
-
+            if args.json: raise CLIError("--wizard cannot be combined with --json")
+            return run_wizard(packs,profiles,recipes,force=args.force)
+        read_modes=sum(bool(v) for v in [args.list_packs,args.catalog,args.list_recipes,args.recommend,args.agent_help])
+        if read_modes>1: raise CLIError("choose only one of --list-packs, --catalog, --list-recipes, --recommend, or --agent-help")
+        if read_modes and (args.recipe or args.profiles or args.category or args.all or args.dry_run or args.yes): raise CLIError("read-only discovery modes cannot be combined with install-selection flags")
+        if args.recipe and (args.profiles or args.category or args.all): raise CLIError("--recipe cannot be combined with --profiles, --category, or --all")
+        if args.tier and not args.recipe: raise CLIError("--tier requires --recipe")
+        fprofiles=[p for p in profiles if not pf or p.pack in pf]; frecipes=[r for r in recipes.values() if not pf or r.pack in pf]
         if args.agent_help:
-            payload = agent_help_payload()
-            if args.json:
-                emit_json(payload)
+            payload=agent_help_payload()
+            if args.json: emit_json(payload)
             else:
                 print("Agent/script usage (non-interactive):")
-                for key, value in payload.items():
-                    if key == "rules":
+                for k,v in payload.items():
+                    if k=="rules":
                         print("\nRules:")
-                        for rule in value:
-                            print(f"  - {rule}")
-                    else:
-                        print(f"  {key:<18} {value}")
+                        for rule in v: print(f"  - {rule}")
+                    else: print(f"  {k:<18} {v}")
             return 0
-
         if args.list_packs:
-            if args.json:
-                emit_json(
-                    {
-                        "packs": [
-                            {
-                                "key": key,
-                                "name": packs[key].name,
-                                "namespace": packs[key].namespace,
-                                "purpose": packs[key].purpose,
-                                "profile_count": sum(1 for p in profiles if p.pack == key),
-                                "version": packs[key].version,
-                            }
-                            for key in ("agency", "council", "academy")
-                            if key in packs and (not pack_filter or key in pack_filter)
-                        ]
-                    }
-                )
-            else:
-                print_pack_list(
-                    {key: value for key, value in packs.items() if not pack_filter or key in pack_filter},
-                    filtered_profiles,
-                )
+            if args.json: emit_json({"packs":[{"key":k,"name":packs[k].name,"namespace":packs[k].namespace,"purpose":packs[k].purpose,"profile_count":sum(1 for p in profiles if p.pack==k),"version":packs[k].version} for k in ("agency","council","academy") if k in packs and (not pf or k in pf)]})
+            else: print_pack_list({k:v for k,v in packs.items() if not pf or k in pf},fprofiles)
             return 0
-
         if args.catalog:
-            if args.json:
-                emit_json(
-                    {
-                        "profile_count": len(filtered_profiles),
-                        "profiles": [profile.as_dict() for profile in filtered_profiles],
-                    }
-                )
-            else:
-                print_catalog(filtered_profiles)
-            return 0
-
+            emit_json({"profile_count":len(fprofiles),"profiles":[p.as_dict() for p in fprofiles]}) if args.json else print_catalog(fprofiles); return 0
+        if args.list_recipes:
+            ordered=sorted(frecipes,key=lambda r:(r.pack,r.id)); emit_json({"recipe_count":len(ordered),"recipes":[r.as_dict() for r in ordered]}) if args.json else print_recipe_list(ordered,profiles=profiles); return 0
         if args.recommend is not None:
-            ranked = recommend_profiles(
-                profiles,
-                args.recommend,
-                limit=args.limit,
-                pack_filter=pack_filter,
-            )
-            if args.json:
-                emit_json(
-                    {
-                        "query": args.recommend,
-                        "limit": args.limit,
-                        "recommendation_count": len(ranked),
-                        "recommendations": [
-                            {**profile.as_dict(), "score": score, "reasons": reasons}
-                            for profile, score, reasons in ranked
-                        ],
-                    }
-                )
+            rr,confident,ranked=recommend_goal(profiles,recipes,args.recommend,limit=args.limit,pack_filter=pf); match,rrecs=_recipe_summary(rr,confident)
+            if args.json: emit_json({"query":args.recommend,"limit":args.limit,"recipe_match":match,"recipe_recommendations":rrecs,"recommendation_count":len(ranked),"recommendations":[{**p.as_dict(),"score":score,"reasons":reasons} for p,score,reasons in ranked]})
             else:
-                if not ranked:
-                    print("No confident recommendations found.")
-                    return 0
                 print(f"Recommended for: {args.recommend}")
-                for profile, score, reasons in ranked:
-                    why = "; ".join(reasons[:3]) or "catalog match"
-                    print(f"  {profile.name:<42} {profile.display_name}  score={score}")
-                    print(f"    {why}")
+                if confident:
+                    r,score,reasons=confident; print(f"\nClear Team Recipe match:\n  {r.id:<28} {r.display_name}  score={score}\n    {'; '.join(reasons[:3]) or r.description}\n    default tier: {recipe_catalog.DEFAULT_TIER} ({len(r.tiers[recipe_catalog.DEFAULT_TIER])} profiles)")
+                elif rr: print("\nNo single Team Recipe is unambiguous enough to promote.")
+                if ranked:
+                    print("\nIndividual profile matches:")
+                    for p,score,reasons in ranked: print(f"  {p.name:<42} {p.display_name}  score={score}\n    {'; '.join(reasons[:3]) or 'catalog match'}")
+                elif not rr: print("No confident recommendations found.")
             return 0
-
-        selected = resolve_selection(
-            profiles,
-            explicit_names=args.profiles,
-            category_specs=args.category,
-            select_all=args.all,
-            pack_filter=pack_filter,
-        )
-        if not selected:
-            raise CLIError(
-                "no profiles selected. Use the wizard, --profiles, --category, --all, --catalog, or --recommend."
-            )
-
-        stats = selected_stats(selected, profiles)
-        plan = {
-            "status": "plan",
-            "profiles": [profile.name for profile in selected],
-            "stats": stats,
-        }
+        context=None
+        if args.recipe:
+            r=recipes.get(args.recipe)
+            if r is None: raise CLIError(f"unknown recipe: {args.recipe}")
+            tier=args.tier or recipe_catalog.DEFAULT_TIER; selected=resolve_recipe_selection(r,tier,profiles,pack_filter=pf); context={"recipe":r.id,"display_name":r.display_name,"pack":r.pack,"tier":tier,"workflow":list(r.workflow),"success_criteria":list(r.success_criteria),"optional_routines":list(r.optional_routines)}
+        else: selected=resolve_selection(profiles,explicit_names=args.profiles,category_specs=args.category,select_all=args.all,pack_filter=pf)
+        if not selected: raise CLIError("no profiles selected. Use the wizard, --recipe, --profiles, --category, --all, --catalog, --list-recipes, or --recommend.")
+        stats=selected_stats(selected,profiles); plan={"status":"plan","profiles":[p.name for p in selected],"stats":stats}; plan.update(context or {})
         if args.dry_run:
-            if args.json:
-                emit_json(plan)
+            if args.json: emit_json(plan)
             else:
-                print(f"Would install {stats['selected_profiles']} profile(s):")
-                for profile in selected:
-                    print(f"  - {profile.name}")
-                print(
-                    f"Estimated source payload: {format_bytes(stats['estimated_source_bytes'])}; "
-                    f"skipping {stats['skipped_profiles']} profile(s)."
-                )
+                print(f"Would install recipe {context['recipe']} ({context['tier']}) with {stats['selected_profiles']} profile(s):" if context else f"Would install {stats['selected_profiles']} profile(s):")
+                for p in selected: print(f"  - {p.name}")
+                print(f"Estimated source payload: {format_bytes(stats['estimated_source_bytes'])}; skipping {stats['skipped_profiles']} profile(s).")
             return 0
-
         if not args.yes:
-            if args.json or not (sys.stdin.isatty() and sys.stdout.isatty()):
-                raise CLIError("installation requires --yes in non-interactive mode; use --dry-run first if desired")
-            print(f"Install {len(selected)} selected profile(s)?")
-            answer = _prompt("Continue? [y/N]: ").lower()
-            if answer not in {"y", "yes"}:
-                print("Nothing installed.")
-                return 0
-
-        code, results = install_selected(selected, packs, force=args.force, json_mode=args.json)
-        if args.json:
-            emit_json(
-                {
-                    "status": "ok" if code == 0 else "error",
-                    "returncode": code,
-                    "profiles": [profile.name for profile in selected],
-                    "stats": stats,
-                    "packs": results,
-                }
-            )
-        elif code == 0:
-            print(f"\nInstalled {len(selected)} selected Hermes profile(s).")
+            if args.json or not (sys.stdin.isatty() and sys.stdout.isatty()): raise CLIError("installation requires --yes in non-interactive mode; use --dry-run first if desired")
+            if _prompt(f"Install {len(selected)} selected profile(s)?\nContinue? [y/N]: ").lower() not in {"y","yes"}: print("Nothing installed."); return 0
+        code,results=install_selected(selected,packs,force=args.force,json_mode=args.json)
+        if args.json: emit_json({**plan,"status":"ok" if code==0 else "error","returncode":code,"packs":results})
+        elif code==0: print(f"\nInstalled {len(selected)} profile(s) from recipe {context['recipe']} ({context['tier']})." if context else f"\nInstalled {len(selected)} selected Hermes profile(s).")
         return code
-
-    except CLIError as exc:
-        if "args" in locals() and getattr(args, "json", False):
-            print(json.dumps({"status": "error", "error": str(exc)}), file=sys.stderr)
-        else:
-            print(f"error: {exc}", file=sys.stderr)
+    except (CLIError,recipe_catalog.RecipeError,json.JSONDecodeError,OSError) as exc:
+        if 'args' in locals() and getattr(args,'json',False): print(json.dumps({"status":"error","error":str(exc)}),file=sys.stderr)
+        else: print(f"error: {exc}",file=sys.stderr)
         return 2
-    except (json.JSONDecodeError, OSError) as exc:
-        if "args" in locals() and getattr(args, "json", False):
-            print(json.dumps({"status": "error", "error": str(exc)}), file=sys.stderr)
-        else:
-            print(f"error: {exc}", file=sys.stderr)
-        return 2
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
+if __name__=="__main__": raise SystemExit(main())

--- a/recipe_catalog.py
+++ b/recipe_catalog.py
@@ -1,0 +1,206 @@
+"""Shared Team Recipe registry, scoring, confidence, and resolution helpers.
+
+This module deliberately has no dependency on the root installer. Both install.py and
+recipes.py use it so recipe behavior has one implementation and one confidence policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+TIER_ORDER = ("minimal", "recommended", "expanded")
+DEFAULT_TIER = "recommended"
+CONFIDENT_RECIPE_SCORE = 24
+CONFIDENT_RECIPE_MARGIN = 8
+
+
+class RecipeError(ValueError):
+    """User-facing recipe error."""
+
+
+@dataclass(frozen=True)
+class Recipe:
+    id: str
+    display_name: str
+    pack: str
+    description: str
+    when_to_use: str
+    keywords: tuple[str, ...]
+    tiers: dict[str, tuple[str, ...]]
+    workflow: tuple[str, ...]
+    success_criteria: tuple[str, ...]
+    optional_routines: tuple[str, ...]
+
+    def as_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "display_name": self.display_name,
+            "pack": self.pack,
+            "description": self.description,
+            "when_to_use": self.when_to_use,
+            "keywords": list(self.keywords),
+            "tiers": {tier: list(self.tiers[tier]) for tier in TIER_ORDER},
+            "workflow": list(self.workflow),
+            "success_criteria": list(self.success_criteria),
+            "optional_routines": list(self.optional_routines),
+        }
+
+    def searchable_text(self) -> str:
+        return " ".join(
+            [
+                self.id.replace("-", " "),
+                self.display_name,
+                self.description,
+                self.when_to_use,
+                *self.keywords,
+            ]
+        ).lower()
+
+
+def load_recipes(root: Path) -> dict[str, Recipe]:
+    path = root / "recipes.json"
+    if not path.is_file():
+        raise RecipeError(f"missing recipe registry: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != 1:
+        raise RecipeError("unsupported recipes.json schema_version")
+
+    recipes: dict[str, Recipe] = {}
+    for item in payload.get("recipes", []):
+        recipe_id = str(item.get("id", ""))
+        if not recipe_id:
+            raise RecipeError("recipe is missing id")
+        if recipe_id in recipes:
+            raise RecipeError(f"duplicate recipe id: {recipe_id}")
+        raw_tiers = item.get("tiers", {})
+        tiers = {
+            tier: tuple(str(name) for name in raw_tiers.get(tier, []))
+            for tier in TIER_ORDER
+        }
+        recipes[recipe_id] = Recipe(
+            id=recipe_id,
+            display_name=str(item.get("display_name") or recipe_id),
+            pack=str(item.get("pack") or ""),
+            description=str(item.get("description") or ""),
+            when_to_use=str(item.get("when_to_use") or ""),
+            keywords=tuple(str(value) for value in item.get("keywords", [])),
+            tiers=tiers,
+            workflow=tuple(str(value) for value in item.get("workflow", [])),
+            success_criteria=tuple(str(value) for value in item.get("success_criteria", [])),
+            optional_routines=tuple(str(value) for value in item.get("optional_routines", [])),
+        )
+    return recipes
+
+
+def resolve_recipe_profiles(
+    recipe: Recipe,
+    tier: str,
+    profiles: Iterable[Any],
+) -> list[Any]:
+    if tier not in TIER_ORDER:
+        raise RecipeError(f"unknown tier '{tier}'. Choose: {', '.join(TIER_ORDER)}")
+    by_name = {profile.name: profile for profile in profiles}
+    selected: list[Any] = []
+    for name in recipe.tiers[tier]:
+        profile = by_name.get(name)
+        if profile is None:
+            raise RecipeError(f"recipe {recipe.id} references unavailable profile: {name}")
+        if profile.pack != recipe.pack:
+            raise RecipeError(
+                f"recipe {recipe.id} belongs to {recipe.pack} but references {name} from {profile.pack}"
+            )
+        selected.append(profile)
+    return selected
+
+
+def _score(
+    recipe: Recipe,
+    query: str,
+    *,
+    expanded_query: Callable[[str], set[str]],
+    tokenize: Callable[[str], set[str]],
+    pack_hints: Mapping[str, set[str]],
+    pack_display: Mapping[str, str],
+) -> tuple[int, list[str]]:
+    query_tokens = expanded_query(query)
+    keyword_tokens = tokenize(" ".join(recipe.keywords))
+    name_tokens = tokenize(recipe.id.replace("-", " ") + " " + recipe.display_name)
+    detail_tokens = tokenize(recipe.description + " " + recipe.when_to_use)
+
+    keyword_hits = sorted(query_tokens & keyword_tokens)
+    name_hits = sorted(query_tokens & name_tokens)
+    detail_hits = sorted(query_tokens & detail_tokens)
+
+    score = len(keyword_hits) * 10 + len(name_hits) * 8 + len(detail_hits) * 3
+    reasons: list[str] = []
+    if keyword_hits:
+        reasons.append("recipe intent: " + ", ".join(keyword_hits[:4]))
+    if name_hits:
+        reasons.append("recipe name: " + ", ".join(name_hits[:3]))
+    if detail_hits:
+        reasons.append("description: " + ", ".join(detail_hits[:3]))
+
+    raw_query = " ".join(query.lower().split())
+    if raw_query and len(raw_query) >= 4 and raw_query in recipe.searchable_text():
+        score += 15
+        reasons.insert(0, "exact phrase match")
+
+    raw_tokens = tokenize(query)
+    pack_hits = sorted(raw_tokens & pack_hints.get(recipe.pack, set()))
+    if pack_hits:
+        score += min(8, 2 * len(pack_hits))
+        reasons.append(f"{pack_display[recipe.pack]} intent")
+    return score, reasons
+
+
+def recommend_recipes(
+    recipes: Iterable[Recipe],
+    query: str,
+    *,
+    expanded_query: Callable[[str], set[str]],
+    tokenize: Callable[[str], set[str]],
+    pack_hints: Mapping[str, set[str]],
+    pack_display: Mapping[str, str],
+    limit: int = 5,
+    pack_filter: set[str] | None = None,
+) -> list[tuple[Recipe, int, list[str]]]:
+    if not query.strip():
+        raise RecipeError("recommendation query cannot be empty")
+    if limit < 1:
+        raise RecipeError("--limit must be at least 1")
+    ranked: list[tuple[Recipe, int, list[str]]] = []
+    for recipe in recipes:
+        if pack_filter and recipe.pack not in pack_filter:
+            continue
+        score, reasons = _score(
+            recipe,
+            query,
+            expanded_query=expanded_query,
+            tokenize=tokenize,
+            pack_hints=pack_hints,
+            pack_display=pack_display,
+        )
+        if score > 0:
+            ranked.append((recipe, score, reasons))
+    ranked.sort(key=lambda item: (-item[1], item[0].pack, item[0].id))
+    return ranked[:limit]
+
+
+def confident_recipe_match(
+    ranked: list[tuple[Recipe, int, list[str]]],
+    *,
+    minimum_score: int = CONFIDENT_RECIPE_SCORE,
+    minimum_margin: int = CONFIDENT_RECIPE_MARGIN,
+) -> tuple[Recipe, int, list[str]] | None:
+    """Return the top recipe only when it is strong and meaningfully unambiguous."""
+    if not ranked:
+        return None
+    top = ranked[0]
+    if top[1] < minimum_score:
+        return None
+    if len(ranked) > 1 and top[1] - ranked[1][1] < minimum_margin:
+        return None
+    return top

--- a/recipes.py
+++ b/recipes.py
@@ -9,86 +9,21 @@ second profile roster or create runtime state.
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
 import json
 from pathlib import Path
 import sys
 from typing import Iterable
 
 import install as profile_installer
+import recipe_catalog
+from recipe_catalog import Recipe, RecipeError, TIER_ORDER
 
 ROOT = Path(__file__).resolve().parent
 RECIPE_FILE = ROOT / "recipes.json"
-TIER_ORDER = ("minimal", "recommended", "expanded")
-
-
-class RecipeError(ValueError):
-    """User-facing recipe error."""
-
-
-@dataclass(frozen=True)
-class Recipe:
-    id: str
-    display_name: str
-    pack: str
-    description: str
-    when_to_use: str
-    keywords: tuple[str, ...]
-    tiers: dict[str, tuple[str, ...]]
-    workflow: tuple[str, ...]
-    success_criteria: tuple[str, ...]
-    optional_routines: tuple[str, ...]
-
-    def as_dict(self) -> dict:
-        return {
-            "id": self.id,
-            "display_name": self.display_name,
-            "pack": self.pack,
-            "description": self.description,
-            "when_to_use": self.when_to_use,
-            "keywords": list(self.keywords),
-            "tiers": {tier: list(self.tiers[tier]) for tier in TIER_ORDER},
-            "workflow": list(self.workflow),
-            "success_criteria": list(self.success_criteria),
-            "optional_routines": list(self.optional_routines),
-        }
-
-    def searchable_text(self) -> str:
-        return " ".join(
-            [self.id.replace("-", " "), self.display_name, self.description, self.when_to_use, *self.keywords]
-        ).lower()
 
 
 def load_recipes(root: Path = ROOT) -> dict[str, Recipe]:
-    path = root / "recipes.json"
-    if not path.is_file():
-        raise RecipeError(f"missing recipe registry: {path}")
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if payload.get("schema_version") != 1:
-        raise RecipeError("unsupported recipes.json schema_version")
-
-    recipes: dict[str, Recipe] = {}
-    for item in payload.get("recipes", []):
-        recipe_id = str(item.get("id", ""))
-        if not recipe_id:
-            raise RecipeError("recipe is missing id")
-        if recipe_id in recipes:
-            raise RecipeError(f"duplicate recipe id: {recipe_id}")
-        raw_tiers = item.get("tiers", {})
-        tiers = {tier: tuple(str(name) for name in raw_tiers.get(tier, [])) for tier in TIER_ORDER}
-        recipes[recipe_id] = Recipe(
-            id=recipe_id,
-            display_name=str(item.get("display_name") or recipe_id),
-            pack=str(item.get("pack") or ""),
-            description=str(item.get("description") or ""),
-            when_to_use=str(item.get("when_to_use") or ""),
-            keywords=tuple(str(value) for value in item.get("keywords", [])),
-            tiers=tiers,
-            workflow=tuple(str(value) for value in item.get("workflow", [])),
-            success_criteria=tuple(str(value) for value in item.get("success_criteria", [])),
-            optional_routines=tuple(str(value) for value in item.get("optional_routines", [])),
-        )
-    return recipes
+    return recipe_catalog.load_recipes(root)
 
 
 def resolve_recipe_profiles(
@@ -96,68 +31,26 @@ def resolve_recipe_profiles(
     tier: str,
     profiles: Iterable[profile_installer.Profile],
 ) -> list[profile_installer.Profile]:
-    if tier not in TIER_ORDER:
-        raise RecipeError(f"unknown tier '{tier}'. Choose: {', '.join(TIER_ORDER)}")
-    by_name = {profile.name: profile for profile in profiles}
-    selected: list[profile_installer.Profile] = []
-    for name in recipe.tiers[tier]:
-        profile = by_name.get(name)
-        if profile is None:
-            raise RecipeError(f"recipe {recipe.id} references unavailable profile: {name}")
-        if profile.pack != recipe.pack:
-            raise RecipeError(
-                f"recipe {recipe.id} belongs to {recipe.pack} but references {name} from {profile.pack}"
-            )
-        selected.append(profile)
-    return selected
-
-
-def _score(recipe: Recipe, query: str) -> tuple[int, list[str]]:
-    query_tokens = profile_installer.expanded_query(query)
-    keyword_tokens = profile_installer.tokenize(" ".join(recipe.keywords))
-    name_tokens = profile_installer.tokenize(recipe.id.replace("-", " ") + " " + recipe.display_name)
-    detail_tokens = profile_installer.tokenize(recipe.description + " " + recipe.when_to_use)
-
-    keyword_hits = sorted(query_tokens & keyword_tokens)
-    name_hits = sorted(query_tokens & name_tokens)
-    detail_hits = sorted(query_tokens & detail_tokens)
-
-    score = len(keyword_hits) * 10 + len(name_hits) * 8 + len(detail_hits) * 3
-    reasons: list[str] = []
-    if keyword_hits:
-        reasons.append("recipe intent: " + ", ".join(keyword_hits[:4]))
-    if name_hits:
-        reasons.append("recipe name: " + ", ".join(name_hits[:3]))
-    if detail_hits:
-        reasons.append("description: " + ", ".join(detail_hits[:3]))
-
-    raw_query = " ".join(query.lower().split())
-    if raw_query and len(raw_query) >= 4 and raw_query in recipe.searchable_text():
-        score += 15
-        reasons.insert(0, "exact phrase match")
-
-    raw_tokens = profile_installer.tokenize(query)
-    pack_hits = sorted(raw_tokens & profile_installer.PACK_HINTS.get(recipe.pack, set()))
-    if pack_hits:
-        score += min(8, 2 * len(pack_hits))
-        reasons.append(f"{profile_installer.PACK_DISPLAY[recipe.pack]} intent")
-    return score, reasons
+    return recipe_catalog.resolve_recipe_profiles(recipe, tier, profiles)
 
 
 def recommend_recipes(
-    recipes: Iterable[Recipe], query: str, *, limit: int = 5
+    recipes: Iterable[Recipe],
+    query: str,
+    *,
+    limit: int = 5,
+    pack_filter: set[str] | None = None,
 ) -> list[tuple[Recipe, int, list[str]]]:
-    if not query.strip():
-        raise RecipeError("recommendation query cannot be empty")
-    if limit < 1:
-        raise RecipeError("--limit must be at least 1")
-    ranked: list[tuple[Recipe, int, list[str]]] = []
-    for recipe in recipes:
-        score, reasons = _score(recipe, query)
-        if score > 0:
-            ranked.append((recipe, score, reasons))
-    ranked.sort(key=lambda item: (-item[1], item[0].pack, item[0].id))
-    return ranked[:limit]
+    return recipe_catalog.recommend_recipes(
+        recipes,
+        query,
+        expanded_query=profile_installer.expanded_query,
+        tokenize=profile_installer.tokenize,
+        pack_hints=profile_installer.PACK_HINTS,
+        pack_display=profile_installer.PACK_DISPLAY,
+        limit=limit,
+        pack_filter=pack_filter,
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -167,6 +60,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("recipe", nargs="?", help="Recipe id, for example software-delivery.")
     parser.add_argument("--list", action="store_true", help="List available recipes and exit.")
     parser.add_argument("--recommend", metavar="TEXT", help="Recommend recipes for a plain-language goal.")
+    parser.add_argument("--pack", action="append", help="Filter recipes by pack; repeatable.")
     parser.add_argument("--tier", choices=TIER_ORDER, default="recommended", help="Recipe size tier (default: recommended).")
     parser.add_argument("--limit", type=int, default=5, help="Maximum recipe recommendations (default: 5).")
     parser.add_argument("--dry-run", action="store_true", help="Resolve the exact recipe profile plan without installing.")
@@ -205,6 +99,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         recipes = load_recipes()
         packs, profiles = profile_installer.load_catalog()
+        pack_filter = profile_installer.filter_packs(args.pack)
 
         read_modes = int(args.list) + int(args.recommend is not None)
         if read_modes > 1:
@@ -215,7 +110,10 @@ def main(argv: list[str] | None = None) -> int:
             raise RecipeError("read-only recipe discovery cannot be combined with install flags")
 
         if args.list:
-            ordered = sorted(recipes.values(), key=lambda recipe: (recipe.pack, recipe.id))
+            ordered = sorted(
+                (recipe for recipe in recipes.values() if not pack_filter or recipe.pack in pack_filter),
+                key=lambda recipe: (recipe.pack, recipe.id),
+            )
             if args.json:
                 _emit({"recipe_count": len(ordered), "recipes": [recipe.as_dict() for recipe in ordered]})
             else:
@@ -229,11 +127,25 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         if args.recommend is not None:
-            ranked = recommend_recipes(recipes.values(), args.recommend, limit=args.limit)
+            ranked = recommend_recipes(
+                recipes.values(), args.recommend, limit=args.limit, pack_filter=pack_filter
+            )
+            confident = recipe_catalog.confident_recipe_match(ranked)
             if args.json:
                 _emit(
                     {
                         "query": args.recommend,
+                        "recipe_match": (
+                            {
+                                "recipe": confident[0].id,
+                                "display_name": confident[0].display_name,
+                                "pack": confident[0].pack,
+                                "score": confident[1],
+                                "reasons": confident[2],
+                            }
+                            if confident
+                            else None
+                        ),
                         "recommendation_count": len(ranked),
                         "recommendations": [
                             {
@@ -254,8 +166,11 @@ def main(argv: list[str] | None = None) -> int:
                     return 0
                 print(f"Recommended team recipes for: {args.recommend}")
                 for recipe, score, reasons in ranked:
-                    print(f"  {recipe.id:<28} {recipe.display_name}  score={score}")
-                    print("    " + ("; ".join(reasons[:3]) or recipe.description))
+                    marker = "  *" if confident and recipe.id == confident[0].id else "   "
+                    print(f"{marker} {recipe.id:<28} {recipe.display_name}  score={score}")
+                    print("      " + ("; ".join(reasons[:3]) or recipe.description))
+                if confident:
+                    print(f"\n* Clear recipe match: {confident[0].display_name}")
             return 0
 
         if not args.recipe:
@@ -263,6 +178,8 @@ def main(argv: list[str] | None = None) -> int:
         recipe = recipes.get(args.recipe)
         if recipe is None:
             raise RecipeError(f"unknown recipe: {args.recipe}")
+        if pack_filter and recipe.pack not in pack_filter:
+            raise RecipeError(f"recipe {recipe.id} is outside the requested --pack filter")
         selected = resolve_recipe_profiles(recipe, args.tier, profiles)
         plan = _recipe_plan(recipe, args.tier, selected, profiles)
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -12,6 +12,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 import install
+import recipe_catalog
 import recipes
 
 
@@ -47,6 +48,60 @@ class RecipeTests(unittest.TestCase):
         ranked = recipes.recommend_recipes(loaded.values(), "build and ship a web app", limit=5)
         self.assertTrue(ranked)
         self.assertTrue(any(item[0].id == "software-delivery" for item in ranked))
+
+    def test_confidence_requires_strength_and_margin(self):
+        loaded = list(recipes.load_recipes(ROOT).values())
+        self.assertGreaterEqual(len(loaded), 2)
+        self.assertIsNone(
+            recipe_catalog.confident_recipe_match(
+                [(loaded[0], 23, []), (loaded[1], 1, [])]
+            )
+        )
+        self.assertIsNone(
+            recipe_catalog.confident_recipe_match(
+                [(loaded[0], 30, []), (loaded[1], 25, [])]
+            )
+        )
+        self.assertEqual(
+            recipe_catalog.confident_recipe_match(
+                [(loaded[0], 32, []), (loaded[1], 20, [])]
+            )[0].id,
+            loaded[0].id,
+        )
+
+    def test_root_installer_promotes_clear_recipe_but_keeps_profile_matches(self):
+        loaded = install.load_recipe_catalog(ROOT)
+        _, profiles = install.load_catalog(ROOT)
+        _, confident, profile_ranked = install.recommend_goal(
+            profiles, loaded, "build and ship a web app", limit=6
+        )
+        self.assertIsNotNone(confident)
+        self.assertEqual(confident[0].id, "software-delivery")
+        self.assertTrue(profile_ranked)
+
+    def test_root_installer_json_recommendation_is_recipe_aware_and_read_only(self):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            code = install.main(["--recommend", "build and ship a web app", "--json"])
+        self.assertEqual(code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["recipe_match"]["recipe"], "software-delivery")
+        self.assertEqual(payload["recipe_match"]["default_tier"], "recommended")
+        self.assertTrue(payload["recipe_recommendations"])
+        self.assertTrue(payload["recommendations"])
+
+    def test_root_installer_can_resolve_recipe_dry_run(self):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            code = install.main(
+                ["--recipe", "api-backend", "--tier", "minimal", "--dry-run", "--json"]
+            )
+        self.assertEqual(code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["status"], "plan")
+        self.assertEqual(payload["recipe"], "api-backend")
+        self.assertEqual(payload["tier"], "minimal")
+        self.assertIn("agency-backend-engineer", payload["profiles"])
 
     def test_json_dry_run_is_read_only_and_exact(self):
         output = io.StringIO()


### PR DESCRIPTION
## Summary

Integrates validated Team Recipes into the canonical root `install.py` discovery and installation experience while preserving the existing profile-level interface and runtime/source boundaries.

### Root wizard
- Recommendation now scores recipes and profiles independently.
- A Team Recipe is promoted only when it clears a conservative confidence gate: minimum score plus minimum lead over the runner-up.
- Users can accept the recipe, choose `minimal` / `recommended` / `expanded`, and review the exact profile plan.
- Declining a recipe immediately falls back to the existing individual-profile recommendation flow.
- Adds a direct **Browse team recipes** wizard path.

### Root agent/script interface
- Adds `--list-recipes`.
- Adds exact `--recipe ID --tier ...` selection with existing `--dry-run`, `--yes`, `--json`, `--force`, and `--pack` semantics.
- Keeps `--recommend` read-only.
- Preserves the existing JSON `recommendations` array as individual profiles and adds `recipe_match` plus `recipe_recommendations` additively.

### Shared engine
- Adds `recipe_catalog.py` as the single dependency-neutral recipe registry/scoring/confidence implementation.
- `install.py` and focused `recipes.py` both use that same engine; there is no duplicated recipe scorer or profile roster.

### Tests/docs
- Adds confidence threshold/margin tests.
- Tests clear recipe promotion while preserving individual profile matches.
- Tests root recipe dry-run JSON resolution.
- Keeps standalone `recipes.py` dry-run coverage.
- Updates README, installer docs, Team Recipes, first-team onboarding, installation verification, changelog, and adds a detailed implementation plan.

## Architectural boundary

Recipe integration remains selection advice only. It does not create memory, learned skills, cron jobs, Bot/group membership, Kanban state, credentials, model configuration, Fleet state, or machine-specific runtime data.

## Compatibility

Legacy pack-first commands remain supported. Existing `--recommend --json` clients can continue reading `recommendations` unchanged.

## Required gate

```bash
python validate.py
python -m unittest discover -s tests -p 'test_*.py'
python -m unittest discover -s hermes-agency/tests -p 'test_*.py'
python -m unittest discover -s hermes-council/tests -p 'test_*.py'
python -m unittest discover -s hermes-academy/tests -p 'test_*.py'
```

Merge only after the exact PR head passes the full CI gate.