### PR TITLE
feat(academy): implement Continuing Education learner, instructor, and Dean flow

### DIFF
--- a/docs/CONTINUING_EDUCATION_ARCHITECTURE.md
+++ b/docs/CONTINUING_EDUCATION_ARCHITECTURE.md
@@ -73,6 +73,18 @@ the constraints for every later phase.
     parallel store is permitted only if upstream Hermes provably cannot
     represent something actually required — and that exception must be
     documented here first.
+11. **Minimum sufficient instruction.** Continuing Education is a
+    competency-transfer system, not a school simulation. Baseline before
+    teaching; teach only demonstrated gaps; combine instructional functions
+    into as few turns as practical; skip instruction when competency is
+    already demonstrated; correct only what failed; require meaningfully
+    different transfer evidence when instruction was needed; and stop as soon
+    as the completion contract is satisfied. Do not impose fixed lesson
+    lengths, modules, ceremonial quizzes, acknowledgement turns, or other
+    classroom roleplay. Invoke `/learn` only when the event produced a
+    reusable capability delta worth persisting. Phase-specific QA scripts may
+    use fixed turn sequences to prove mechanics, but those sequences are test
+    scaffolding and must not become the production teaching protocol.
 
 ## Transport decision (deferred)
 

--- a/hermes-academy/profiles/academy-arts-design-instructor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-arts-design-instructor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-automotive-instructor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-automotive-instructor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-biology-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-biology-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-business-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-business-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-chemistry-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-chemistry-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-cloud-systems-instructor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-cloud-systems-instructor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-computer-science-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-computer-science-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-culinary-arts-instructor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-culinary-arts-instructor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-cybersecurity-instructor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-cybersecurity-instructor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-data-science-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-data-science-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-dean/skills/faculty-routing/SKILL.md
+++ b/hermes-academy/profiles/academy-dean/skills/faculty-routing/SKILL.md
@@ -11,3 +11,23 @@ Prefer the most specific installed Academy faculty member before a broad chair. 
 Use the same specific-over-broad rule for statistics, data science, philosophy, law and legal studies, theology and religious studies, education and pedagogy, cybersecurity, cloud and systems, project management, automotive, culinary arts, and music when the dedicated v0.2 faculty member is installed.
 
 If no exact specialist exists, choose the closest broad faculty profile and state the limitation instead of inventing expertise.
+
+## Profile Learner Routing
+
+When a Hermes profile (e.g. `agency-backend-engineer`) requests education, route using the Academy manifest as authority:
+
+1. **Input contract.** Accept only: learner profile name, learner role, one requested objective, and optionally relevant skill names/descriptions. Never accept full profile state, memory, secrets, or conversation history.
+
+2. **Specialist preference first.** Check `academy.json` → `routing.specialist_preferences` for an exact topic match. If the specialist profile is installed, route there.
+
+3. **Broad chair fallback.** If no specialist matches, check `routing.broad_chairs` for an interdisciplinary fallback. Mark the match as approximate.
+
+4. **Category fallback.** If the specialist preference exists but the profile is not installed, fall back to the broad representative of that category (e.g. `academy-computer-science-professor` for technology topics). Mark the match as approximate.
+
+5. **Role-description scan.** As a last resort, match the objective against faculty role descriptions. Choose the profile with the most keyword overlap. Mark the match as approximate.
+
+6. **Never invent.** If no installed faculty member is a safe match, say so. Never fabricate a profile name.
+
+7. **Label approximation.** Always tell the learner whether the match is exact or approximate. An approximate match means the faculty member covers the broad area but may not have the narrow specialty.
+
+Use `routing.py` → `route_learner()` for deterministic routing decisions.

--- a/hermes-academy/profiles/academy-dean/skills/learner-brief/SKILL.md
+++ b/hermes-academy/profiles/academy-dean/skills/learner-brief/SKILL.md
@@ -7,3 +7,22 @@ description: Create a compact teaching brief with learning goal, approximate lev
 Capture only what affects instruction: what the learner wants to be able to understand or do, their approximate starting point, relevant prior knowledge, time or tool constraints, and whether they want explanation, practice, review, or direct help.
 
 Do not demand information that can be inferred safely from the conversation.
+
+## Profile Learner Context Minimization
+
+When the learner is a Hermes profile (e.g. `agency-backend-engineer`), the brief must contain only what the receiving faculty member needs:
+
+**Include:**
+- Learner profile name (identity)
+- Learner role (one-line description of what the profile does)
+- Requested objective (one clear learning goal)
+- Relevant skill names or descriptions when they directly affect instruction
+
+**Never include:**
+- Full profile state or configuration
+- Memory contents or conversation history
+- Secrets, credentials, or API keys
+- Internal tool schemas or implementation details
+- Unrelated skills or capabilities
+
+Use `routing.py` → `minimize_learner_context()` to build the minimized context object. The function accepts learner profile name, role, objective, and an optional list of relevant skill names, and returns a `LearnerContext` containing only those four fields.

--- a/hermes-academy/profiles/academy-economics-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-economics-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-education-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-education-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-engineering-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-engineering-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-health-sciences-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-health-sciences-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-history-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-history-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-language-instructor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-language-instructor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-law-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-law-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-mathematics-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-mathematics-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-music-instructor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-music-instructor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-natural-sciences-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-natural-sciences-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-philosophy-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-philosophy-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-physics-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-physics-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-project-management-instructor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-project-management-instructor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-research-methods-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-research-methods-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-skilled-trades-instructor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-skilled-trades-instructor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-social-sciences-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-social-sciences-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-statistics-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-statistics-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-theology-religious-studies-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-theology-religious-studies-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/profiles/academy-writing-rhetoric-professor/skills/teach-profile/SKILL.md
+++ b/hermes-academy/profiles/academy-writing-rhetoric-professor/skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/routing.py
+++ b/hermes-academy/routing.py
@@ -131,6 +131,21 @@ TOPIC_KEYWORDS: dict[str, list[str]] = {
     ],
 }
 
+# Single words in this set are useful evidence only in context. They are too
+# ambiguous to justify a confident specialist route by themselves. Two or
+# more hits in the same topic, or one distinctive/multi-word keyword, may
+# still produce a specialist match.
+AMBIGUOUS_SINGLE_KEYWORDS = {
+    "dynamics", "momentum", "energy", "waves", "force",
+    "bonding", "reaction", "compound", "element", "solution", "acid", "base",
+    "cell", "regression", "distribution", "inference", "modeling",
+    "ethics", "moral", "logic", "aesthetics", "contract", "regulation",
+    "faith", "church", "temple", "sacred", "teaching", "instruction",
+    "assessment", "classroom", "security", "infrastructure", "container",
+    "engine", "transmission", "diagnostic", "torque", "scale", "composition",
+    "instrument",
+}
+
 
 def _load_manifest(path: Optional[Path] = None) -> dict:
     target = path or MANIFEST
@@ -167,14 +182,22 @@ def _topic_from_objective(objective: str) -> Optional[str]:
             # (e.g. "base" matching inside "database")
             pattern = r'\b' + re.escape(kw) + r'\b'
             if re.search(pattern, objective_lower):
-                # Multi-word keywords get higher weight (more specific)
                 word_count = len(kw.split())
-                score += word_count
+                if word_count > 1:
+                    # Phrases are strong evidence and outrank single words.
+                    score += word_count + 1
+                elif kw in AMBIGUOUS_SINGLE_KEYWORDS:
+                    # One ambiguous word is context, not a confident route.
+                    score += 1
+                else:
+                    # Distinctive domain terms may route confidently alone.
+                    score += 2
         if score > best_score:
             best_score = score
             best = topic_key
 
-    return best if best_score > 0 else None
+    # A lone ambiguous single-word hit scores 1 and is deliberately rejected.
+    return best if best_score >= 2 else None
 
 
 def _is_interdisciplinary(objective: str) -> bool:
@@ -310,7 +333,10 @@ def route_learner(
             best_score = score
             best = profile["name"]
 
-    if best and best_score > 0:
+    # A single shared word is too weak for a safe approximate route. Requiring
+    # at least two role-description hits prevents cases such as "base jumping"
+    # or "fashion modeling" from being sent to an unrelated faculty member.
+    if best and best_score >= 2:
         return RoutingResult(
             faculty=best,
             approximate=True,

--- a/hermes-academy/routing.py
+++ b/hermes-academy/routing.py
@@ -1,0 +1,348 @@
+"""Deterministic Academy Dean routing for profile learners.
+
+Routes a profile learner (name, role, objective) to the most specific
+installed Academy faculty member using the academy.json manifest as
+authority.  Never invents a profile that does not exist in the catalog.
+
+Public API:
+    route_learner(learner_profile, objective, manifest_path=None)
+    minimize_learner_context(learner_profile, role, objective, skills=None)
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+MANIFEST = Path(__file__).resolve().parent / "academy.json"
+
+
+@dataclass(frozen=True)
+class RoutingResult:
+    """Outcome of a routing decision."""
+    faculty: Optional[str]
+    approximate: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class LearnerContext:
+    """Minimized context passed to a faculty member about the learner."""
+    learner_profile: str
+    role: str
+    objective: str
+    relevant_skills: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Category mapping: manifest category → broad fallback profile
+# ---------------------------------------------------------------------------
+CATEGORY_BROAD_FALLBACK: dict[str, str] = {
+    "quantitative": "academy-mathematics-professor",
+    "communication": "academy-writing-rhetoric-professor",
+    "science": "academy-natural-sciences-professor",
+    "technology": "academy-computer-science-professor",
+    "humanities": "academy-history-professor",
+    "social-sciences": "academy-social-sciences-professor",
+    "professional": "academy-business-professor",
+    "languages": "academy-language-instructor",
+    "research": "academy-research-methods-professor",
+    "vocational": "academy-skilled-trades-instructor",
+    "health-sciences": "academy-health-sciences-professor",
+    "creative": "academy-arts-design-instructor",
+}
+
+# ---------------------------------------------------------------------------
+# Keyword expansion: maps common related terms to specialist_preferences keys.
+# Each entry lists words/phrases that, when found in the objective, indicate
+# the corresponding topic.  The topic key itself is always implied.
+# ---------------------------------------------------------------------------
+TOPIC_KEYWORDS: dict[str, list[str]] = {
+    "physics": [
+        "physics", "mechanics", "thermodynamics", "kinematics", "dynamics",
+        "newton", "momentum", "energy", "waves", "optics", "electromagnetism",
+        "quantum", "relativity", "gravitation", "force", "velocity",
+        "acceleration", "inertia",
+    ],
+    "chemistry": [
+        "chemistry", "chemical", "bonding", "molecular", "stoichiometry",
+        "reaction", "compound", "element", "atom", "organic chemistry",
+        "inorganic", "periodic table", "solution", "acid", "base",
+    ],
+    "biology": [
+        "biology", "biological", "cell", "genetics", "evolution", "ecology",
+        "physiology", "organism", "dna", "rna", "protein", "metabolism",
+        "photosynthesis", "respiration",
+    ],
+    "statistics": [
+        "statistics", "statistical", "probability", "hypothesis testing",
+        "regression", "distribution", "sampling", "confidence interval",
+        "p-value", "bayesian", "inference",
+    ],
+    "data-science": [
+        "data science", "data analysis", "machine learning", "modeling",
+        "feature engineering", "data pipeline", "predictive",
+        "database", "query optimization", "indexing",
+    ],
+    "philosophy": [
+        "philosophy", "philosophical", "ethics", "moral", "logic",
+        "epistemology", "metaphysics", "ontology", "aesthetics",
+        "existentialism", "phenomenology",
+    ],
+    "law-and-legal-studies": [
+        "law", "legal", "constitutional", "contract", "tort",
+        "jurisprudence", "litigation", "statute", "regulation",
+    ],
+    "theology-and-religious-studies": [
+        "theology", "religious", "doctrine", "scripture", "faith",
+        "spirituality", "church", "mosque", "temple", "sacred",
+    ],
+    "education-and-pedagogy": [
+        "pedagogy", "teaching", "instruction", "curriculum", "assessment",
+        "learning science", "educational", "classroom",
+    ],
+    "cybersecurity": [
+        "cybersecurity", "security", "threat model", "threat modeling",
+        "vulnerability", "penetration", "firewall", "encryption",
+        "authentication", "authorization", "incident response",
+    ],
+    "cloud-and-systems": [
+        "cloud", "infrastructure", "distributed systems", "kubernetes",
+        "docker", "aws", "azure", "gcp", "devops", "site reliability",
+        "microservices", "container",
+    ],
+    "project-management": [
+        "project management", "agile", "scrum", "kanban", "sprint",
+        "backlog", "stakeholder", "milestone", "gantt", "waterfall",
+    ],
+    "automotive": [
+        "automotive", "engine", "transmission", "brake", "suspension",
+        "diagnostic", "obd", "vehicle", "mechanic", "torque",
+    ],
+    "culinary-arts": [
+        "culinary", "cooking", "baking", "recipe", "kitchen",
+        "gastronomy", "food safety", "cuisine", "chef",
+    ],
+    "music": [
+        "music", "musical", "rhythm", "melody", "harmony", "chord",
+        "scale", "composition", "ear training", "instrument",
+    ],
+}
+
+
+def _load_manifest(path: Optional[Path] = None) -> dict:
+    target = path or MANIFEST
+    return json.loads(target.read_text(encoding="utf-8"))
+
+
+def _profile_names(manifest: dict) -> set[str]:
+    return {p["name"] for p in manifest["profiles"]}
+
+
+def _profile_by_name(manifest: dict) -> dict[str, dict]:
+    return {p["name"]: p for p in manifest["profiles"]}
+
+
+def _topic_from_objective(objective: str) -> Optional[str]:
+    """Extract a specialist_preferences key from the objective text.
+
+    Uses keyword expansion (TOPIC_KEYWORDS) to map natural-language terms
+    in the objective to the corresponding specialist_preferences key.
+    Returns the most specific match (topic with the most keyword hits).
+    """
+    objective_lower = objective.lower()
+    manifest = _load_manifest()
+    prefs = manifest.get("routing", {}).get("specialist_preferences", {})
+
+    best: Optional[str] = None
+    best_score = 0
+
+    for topic_key in prefs:
+        keywords = TOPIC_KEYWORDS.get(topic_key, [topic_key.replace("-", " ")])
+        score = 0
+        for kw in keywords:
+            # Use word-boundary matching to avoid substring false positives
+            # (e.g. "base" matching inside "database")
+            pattern = r'\b' + re.escape(kw) + r'\b'
+            if re.search(pattern, objective_lower):
+                # Multi-word keywords get higher weight (more specific)
+                word_count = len(kw.split())
+                score += word_count
+        if score > best_score:
+            best_score = score
+            best = topic_key
+
+    return best if best_score > 0 else None
+
+
+def _is_interdisciplinary(objective: str) -> bool:
+    """Check if an objective spans multiple academic domains.
+
+    Returns True if keywords from 2+ different specialist_preferences
+    topics appear in the objective, indicating a genuinely cross-domain request.
+
+    Uses a stricter threshold: requires at least 2 distinct domains with
+    keyword hits, and excludes generic single-word keywords that appear
+    across many domains (like "modeling", "analysis", "design").
+    """
+    objective_lower = objective.lower()
+    manifest = _load_manifest()
+    prefs = manifest.get("routing", {}).get("specialist_preferences", {})
+
+    # Generic words that appear across many domains and shouldn't trigger
+    # interdisciplinary detection on their own
+    GENERIC_WORDS = {
+        "modeling", "analysis", "design", "system", "systems", "theory",
+        "practice", "method", "methods", "research", "evaluation",
+        "management", "engineering", "science", "learning", "education",
+        "security", "data", "model", "models",
+    }
+
+    domains_hit: set[str] = set()
+    for topic_key in prefs:
+        keywords = TOPIC_KEYWORDS.get(topic_key, [topic_key.replace("-", " ")])
+        for kw in keywords:
+            # Skip generic single-word keywords for interdisciplinary detection
+            if len(kw.split()) == 1 and kw in GENERIC_WORDS:
+                continue
+            pattern = r'\b' + re.escape(kw) + r'\b'
+            if re.search(pattern, objective_lower):
+                domains_hit.add(topic_key)
+                break  # One hit per domain is enough
+
+    return len(domains_hit) >= 2
+
+
+def route_learner(
+    learner_profile: str,
+    objective: str,
+    manifest_path: Optional[Path] = None,
+) -> RoutingResult:
+    """Route a profile learner to the best Academy faculty member.
+
+    Parameters
+    ----------
+    learner_profile : str
+        Name of the requesting profile (e.g. "agency-backend-engineer").
+    objective : str
+        One-line learning objective.
+    manifest_path : Path, optional
+        Override manifest location (defaults to academy.json).
+
+    Returns
+    -------
+    RoutingResult
+        faculty: profile name or None if no safe match exists.
+        approximate: True when the match is a broad fallback, not a specialist.
+        reason: human-readable explanation of the routing decision.
+    """
+    manifest = _load_manifest(manifest_path)
+    installed = _profile_names(manifest)
+    prefs = manifest.get("routing", {}).get("specialist_preferences", {})
+    broad_chairs = set(manifest.get("routing", {}).get("broad_chairs", []))
+
+    # 1. Try specialist_preferences (most specific)
+    topic = _topic_from_objective(objective)
+    if topic and topic in prefs:
+        # Check if the request is genuinely interdisciplinary (spans multiple domains)
+        if _is_interdisciplinary(objective):
+            for chair in broad_chairs:
+                if chair in installed:
+                    return RoutingResult(
+                        faculty=chair,
+                        approximate=True,
+                        reason=(
+                            f"Request spans multiple disciplines; "
+                            f"routing to broad chair '{chair}'."
+                        ),
+                    )
+
+        specialist = prefs[topic]
+        if specialist in installed:
+            return RoutingResult(
+                faculty=specialist,
+                approximate=False,
+                reason=f"Direct specialist match for '{topic}'.",
+            )
+        # Specialist preference exists but profile not installed —
+        # fall back to the category's broad representative.
+        for profile in manifest["profiles"]:
+            if profile["name"] == specialist:
+                cat = profile.get("category", "")
+                fallback = CATEGORY_BROAD_FALLBACK.get(cat)
+                if fallback and fallback in installed:
+                    return RoutingResult(
+                        faculty=fallback,
+                        approximate=True,
+                        reason=(
+                            f"Specialist '{specialist}' not installed; "
+                            f"falling back to category broad faculty "
+                            f"'{fallback}'."
+                        ),
+                    )
+
+    # 2. Role-description scan for requests without a clear topic match
+    objective_lower = objective.lower()
+    # Filter out common stop words so weak matches don't dominate
+    STOP_WORDS = {
+        "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+        "of", "with", "by", "from", "is", "are", "was", "were", "be", "been",
+        "being", "have", "has", "had", "do", "does", "did", "will", "would",
+        "could", "should", "may", "might", "shall", "can", "need", "me",
+        "i", "my", "your", "our", "their", "its", "it", "this", "that",
+        "these", "those", "some", "any", "no", "not", "so", "very", "too",
+        "just", "about", "how", "what", "which", "who", "when", "where",
+        "why", "if", "then", "than", "also", "more", "most", "other",
+        "into", "over", "after", "before", "between", "under", "again",
+    }
+    objective_words = [
+        w for w in objective_lower.split()
+        if w.isalpha() and w not in STOP_WORDS
+    ]
+    best: Optional[str] = None
+    best_score = 0
+    for profile in manifest["profiles"]:
+        role_desc = profile.get("role", "").lower()
+        score = sum(1 for word in objective_words if word in role_desc)
+        if score > best_score:
+            best_score = score
+            best = profile["name"]
+
+    if best and best_score > 0:
+        return RoutingResult(
+            faculty=best,
+            approximate=True,
+            reason=(
+                f"No specialist matched; "
+                f"closest role-description match is '{best}'."
+            ),
+        )
+
+    # 3. No match at all
+    return RoutingResult(
+        faculty=None,
+        approximate=False,
+        reason="No Academy faculty member matches this objective.",
+    )
+
+
+def minimize_learner_context(
+    learner_profile: str,
+    role: str,
+    objective: str,
+    skills: Optional[list[str]] = None,
+) -> LearnerContext:
+    """Build a minimized learner context for the receiving faculty.
+
+    Only includes what affects instruction: profile name, role, objective,
+    and optionally relevant skill names.  Never includes full profile state,
+    memory, secrets, or conversations.
+    """
+    return LearnerContext(
+        learner_profile=learner_profile,
+        role=role,
+        objective=objective,
+        relevant_skills=tuple(skills) if skills else (),
+    )

--- a/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
+++ b/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-academy/shared-skills/teach-profile/SKILL.md
+++ b/hermes-academy/shared-skills/teach-profile/SKILL.md
@@ -1,12 +1,125 @@
 ---
 name: teach-profile
-description: Instructor-facing skill for teaching via Hermes profiles. Placeholder — final prose is a later phase.
+description: Use when teaching a Hermes profile a bounded competency.
 ---
 # Teach Profile
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/teach-profile/SKILL.md`.
+Use this skill when an Academy faculty profile is teaching another Hermes profile as part of Continuing Education.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into Academy instructor profiles.
+The purpose is measurable competency transfer, not classroom roleplay. Teach the smallest amount necessary for the learner to demonstrate the target capability on a meaningfully different problem.
+
+## Identify the learner mode
+
+First distinguish between a human learner and a Hermes-profile learner.
+
+For a human learner, teach normally within this instructor's subject and safety boundaries. Do not impose the profile-learning workflow below unless the user explicitly asks for it.
+
+For a Hermes-profile learner, follow this contract.
+
+## Authority boundaries
+
+- The Instructor supplies subject-matter instruction, feedback, correction, and assessment only.
+- Never edit the learner's skills, `SOUL.md`, configuration, permissions, memory, profile metadata, or unrelated state.
+- Never ask for secrets, credentials, full memory, or unrelated conversations.
+- Receive only the learner identity/role, one bounded objective, concise baseline evidence, and relevant skill names/descriptions when they materially affect instruction.
+- Do not create a training database, scheduler, candidate-skill registry, alternate message bus, or other persistence layer.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- Do not silently route the learner into another class. You may recommend follow-up study, but the learner or user must explicitly choose it.
+
+## Minimum-sufficient teaching loop
+
+The following are logical functions, not mandatory conversational stages. Combine or skip them whenever possible.
+
+### 1. Confirm the competency
+
+Restate the requested objective as an observable capability. If the request is outside this instructor's subject or safety boundary, say so and stop or recommend the appropriate Academy faculty member.
+
+Do not expand the objective merely because adjacent material is interesting.
+
+### 2. Read the baseline before teaching
+
+Use the learner's baseline attempt to determine what is already demonstrated and what is missing.
+
+If the baseline already proves the requested competency, declare that no instruction is required. Do not manufacture a lesson, quiz, or skill delta.
+
+If gaps exist, name them precisely. Teach only those gaps.
+
+### 3. Instruct concisely
+
+Explain the missing concept, procedure, heuristic, or decision rule in the shortest form that is sufficient for correct application.
+
+Model an example only when an example materially helps resolve the demonstrated gap. Do not dump the instructor's entire subject knowledge into the conversation.
+
+Every instructional message must materially do at least one of these jobs:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess application;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a message does none of these, omit it.
+
+Avoid greetings, ceremony, fake lesson numbering, acknowledgement ping-pong, repeated summaries, and professor/student theater.
+
+### 4. Require transfer when instruction occurred
+
+After teaching, assess the learner on a meaningfully different problem that requires the same underlying competency.
+
+A valid transfer task should change surface details or operating context enough that the learner must apply the principle rather than copy the demonstrated answer.
+
+Do not accept any of the following as mastery:
+
+- "I understand" or another acknowledgement;
+- paraphrasing the instructor;
+- repeating the worked example;
+- reproducing memorized wording without correct application;
+- a solution that still contains a critical misconception relevant to the objective.
+
+If the learner fails, correct only the failed part and request the minimum retry needed to prove the correction. Do not restart the whole lesson.
+
+### 5. Make an explicit mastery judgment
+
+Return one of these outcomes:
+
+- **MASTERED**: the learner demonstrated the requested competency, including transfer when instruction was required;
+- **NEEDS_CORRECTION**: one or more specific gaps remain and another bounded attempt is warranted;
+- **BLOCKED**: the objective cannot be safely or reliably completed in the current session.
+
+Do not declare mastery because a conversation has been long enough or because a predetermined number of turns occurred.
+
+Stop immediately once the requested competency is demonstrated.
+
+## Completion summary for the learner
+
+When the event ends, provide a compact handoff that the learner can use when deciding whether native `/learn` should persist a capability delta.
+
+Include:
+
+- objective;
+- baseline capability already demonstrated;
+- gaps actually taught, if any;
+- corrections that materially changed the learner's reasoning or procedure;
+- transfer evidence;
+- mastery outcome;
+- concise reusable principles or procedures worth retaining;
+- optional follow-up recommendation, clearly marked as a recommendation rather than an automatic next class.
+
+Do not create or edit the learner's skill yourself. The learner owns the `/learn` decision and the normal Hermes `skill_manage` persistence path.
+
+If the learner already had the capability or the session produced no reusable delta, say that explicitly so `/learn` can be skipped.
+
+## Efficiency standard
+
+Optimize for capability gain per unit of inference.
+
+A two-turn correction that produces verified transfer is better than a ten-turn simulated lesson. More instruction is justified only when it increases the evidence of competency or corrects a demonstrated failure.
+
+When already available without additional work, report compact efficiency facts such as instructor turns, learner turns, retries, baseline result, and transfer result. Do not spend extra inference merely to collect metrics.
+
+## Safety and subject limits
+
+Stay within this instructor profile's subject, professional, and safety boundaries throughout the session. Continuing Education does not grant broader authority than the instructor or learner already has.
+
+When a request is unsafe, outside scope, or requires authority the learner does not possess, refuse or redirect that portion while teaching any safe, in-scope competency that remains useful.

--- a/hermes-academy/tests/test_continuing_education_skill.py
+++ b/hermes-academy/tests/test_continuing_education_skill.py
@@ -1,0 +1,115 @@
+"""Focused contract tests for the Academy learner CE shared skill."""
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+ACADEMY_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = ACADEMY_ROOT.parent
+CANONICAL = ACADEMY_ROOT / "shared-skills" / "academy-continuing-education" / "SKILL.md"
+ACADEMY_MANIFEST = json.loads((ACADEMY_ROOT / "academy.json").read_text(encoding="utf-8"))
+AGENCY_MANIFEST = json.loads(
+    (REPO_ROOT / "hermes-agency" / "agency.json").read_text(encoding="utf-8")
+)
+
+
+def _frontmatter_value(text: str, key: str) -> str:
+    match = re.search(rf"^{re.escape(key)}:\s*(.+)$", text, flags=re.MULTILINE)
+    if not match:
+        raise AssertionError(f"missing frontmatter key: {key}")
+    return match.group(1).strip().strip('"\'')
+
+
+class ContinuingEducationSkillTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = CANONICAL.read_text(encoding="utf-8")
+        cls.data = CANONICAL.read_bytes()
+
+    def test_frontmatter_is_routing_safe(self):
+        self.assertEqual(
+            _frontmatter_value(self.text, "name"),
+            "academy-continuing-education",
+        )
+        description = _frontmatter_value(self.text, "description")
+        self.assertLessEqual(len(description), 60)
+        self.assertTrue(description.endswith("."))
+
+    def test_native_hermes_primitives_are_the_only_learning_path(self):
+        for marker in ("`/goal`", "`message_agent`", "`/learn`", "`skill_manage`"):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.text)
+        for forbidden in (
+            "candidate-skill registry",
+            "alternate message bus",
+            "parallel memory store",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertIn(forbidden, self.text)
+
+    def test_minimum_sufficient_instruction_contract_is_explicit(self):
+        required = (
+            "competency-transfer system, not a school simulation",
+            "minimum instruction required",
+            "Baseline before teaching",
+            "If the baseline already demonstrates the competency strongly enough, stop.",
+            "Do not require fixed lesson lengths",
+            "Stop as soon as the completion contract is satisfied.",
+            "If there is no reusable delta, skip `/learn`.",
+            "minimum inference cost",
+        )
+        for marker in required:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.text)
+
+    def test_peer_wait_and_no_duplicate_request_contract_is_explicit(self):
+        self.assertIn("allow native `/goal` peer-wait behavior to park the goal", self.text)
+        self.assertIn("Do not send duplicate requests", self.text)
+        self.assertIn("burn turns", self.text)
+        self.assertIn("declare success while waiting", self.text)
+
+    def test_authority_and_source_isolation_are_explicit(self):
+        self.assertIn("must never edit this learner's skills", self.text)
+        self.assertIn("Learning must remain local to this learner", self.text)
+        self.assertIn("Never modify Profile Packs source", self.text)
+        self.assertIn("Do not ask the instructor to write it", self.text)
+        for forbidden_system in (
+            "Fleet",
+            "Keryx",
+            "Nodescale",
+            "Templar",
+            "RunAuthority",
+            "Run Capsules",
+        ):
+            self.assertIn(forbidden_system, self.text)
+
+    def test_every_agency_profile_materializes_the_canonical_bytes(self):
+        names = [profile["name"] for profile in AGENCY_MANIFEST["profiles"]]
+        self.assertGreater(len(names), 0)
+        for name in names:
+            with self.subTest(profile=name):
+                materialized = (
+                    REPO_ROOT
+                    / "hermes-agency"
+                    / "profiles"
+                    / name
+                    / "skills"
+                    / "academy-continuing-education"
+                    / "SKILL.md"
+                )
+                self.assertTrue(materialized.is_file(), f"missing {materialized}")
+                self.assertEqual(materialized.read_bytes(), self.data)
+
+    def test_manifest_targets_agency_ce_participants(self):
+        entry = next(
+            skill
+            for skill in ACADEMY_MANIFEST["shared_skills"]
+            if skill["name"] == "academy-continuing-education"
+        )
+        self.assertEqual(entry["targets"]["mode"], "agency-ce-participants")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hermes-academy/tests/test_routing.py
+++ b/hermes-academy/tests/test_routing.py
@@ -1,0 +1,195 @@
+"""Deterministic routing tests for Academy Dean profile-education routing.
+
+Tests the route_learner() and minimize_learner_context() functions from
+hermes-academy/routing.py against the real academy.json manifest.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+# Ensure the academy package root is importable
+import sys
+ACADEMY_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ACADEMY_ROOT))
+
+from routing import route_learner, minimize_learner_context, RoutingResult, LearnerContext
+
+MANIFEST = ACADEMY_ROOT / "academy.json"
+
+
+class DirectSpecialistTest(unittest.TestCase):
+    """A request that clearly matches an installed specialist routes there exactly."""
+
+    def test_physics_request_routes_to_physics_professor(self):
+        result = route_learner(
+            learner_profile="agency-backend-engineer",
+            objective="I want to understand classical mechanics and Newton's laws",
+        )
+        self.assertEqual(result.faculty, "academy-physics-professor")
+        self.assertFalse(result.approximate)
+        self.assertIn("specialist", result.reason.lower())
+
+    def test_chemistry_request_routes_to_chemistry_professor(self):
+        result = route_learner(
+            learner_profile="agency-data-scientist",
+            objective="Teach me chemical bonding and molecular structure",
+        )
+        self.assertEqual(result.faculty, "academy-chemistry-professor")
+        self.assertFalse(result.approximate)
+
+    def test_cybersecurity_request_routes_to_cybersecurity_instructor(self):
+        result = route_learner(
+            learner_profile="agency-security-engineer",
+            objective="I need to learn cybersecurity threat modeling fundamentals",
+        )
+        self.assertEqual(result.faculty, "academy-cybersecurity-instructor")
+        self.assertFalse(result.approximate)
+
+
+class BroadFallbackTest(unittest.TestCase):
+    """A request that spans multiple specialties routes to a broad chair, marked approximate."""
+
+    def test_interdisciplinary_science_routes_to_natural_sciences_chair(self):
+        result = route_learner(
+            learner_profile="agency-research-analyst",
+            objective="I want to understand the scientific method across physics, chemistry, and biology",
+        )
+        # The objective contains physics, chemistry, and biology keywords.
+        # The specialist_preferences will match the longest key whose words
+        # all appear.  "physics" and "chemistry" and "biology" are separate
+        # keys, so the longest match wins.  But the broad_chairs check
+        # happens when no specialist matches cleanly — let's verify the
+        # actual behavior.
+        self.assertIsNotNone(result.faculty)
+        # If a specialist matched, approximate should be False.
+        # If broad chair matched, approximate should be True.
+        # Either is acceptable for this cross-domain request.
+        if result.faculty == "academy-natural-sciences-professor":
+            self.assertTrue(result.approximate)
+
+    def test_broad_science_request_uses_broad_chair(self):
+        """A general 'scientific reasoning' request without specific discipline keywords
+        should fall through to the broad chair."""
+        result = route_learner(
+            learner_profile="agency-product-manager",
+            objective="Teach me how to evaluate scientific evidence and research claims",
+        )
+        self.assertIsNotNone(result.faculty)
+        # Should route somewhere — either a specialist or broad chair
+        self.assertIsInstance(result.approximate, bool)
+
+
+class MissingFacultyTest(unittest.TestCase):
+    """A request for a topic with no matching faculty returns None and explains why."""
+
+    def test_no_matching_faculty_returns_none(self):
+        result = route_learner(
+            learner_profile="agency-frontend-engineer",
+            objective="Teach me advanced basket weaving techniques using traditional methods",
+        )
+        # basket weaving has no faculty — but role-description scan may
+        # still find a weak match.  Verify the result is either None or
+        # explicitly approximate with a clear reason.
+        if result.faculty is None:
+            self.assertIn("no", result.reason.lower())
+        else:
+            self.assertTrue(result.approximate)
+            self.assertIn("closest", result.reason.lower())
+
+    def test_completely_unrelated_request_returns_none_or_approximate(self):
+        result = route_learner(
+            learner_profile="agency-designer",
+            objective="Help me learn professional underwater welding certification",
+        )
+        self.assertIsNotNone(result)
+        # Should either be None (no match) or an approximate vocational match
+        if result.faculty is not None:
+            self.assertTrue(result.approximate)
+
+
+class ProfileLearnerContextMinimizationTest(unittest.TestCase):
+    """The minimized learner context contains only what affects instruction."""
+
+    def test_minimized_context_has_only_four_fields(self):
+        ctx = minimize_learner_context(
+            learner_profile="agency-backend-engineer",
+            role="Implements backend services and APIs",
+            objective="Learn database indexing strategies",
+            skills=["api-design", "sql-optimization"],
+        )
+        self.assertIsInstance(ctx, LearnerContext)
+        self.assertEqual(ctx.learner_profile, "agency-backend-engineer")
+        self.assertEqual(ctx.role, "Implements backend services and APIs")
+        self.assertEqual(ctx.objective, "Learn database indexing strategies")
+        self.assertEqual(ctx.relevant_skills, ("api-design", "sql-optimization"))
+
+    def test_minimized_context_without_skills(self):
+        ctx = minimize_learner_context(
+            learner_profile="agency-product-manager",
+            role="Defines product behavior and acceptance criteria",
+            objective="Understand statistical significance in A/B tests",
+        )
+        self.assertEqual(ctx.relevant_skills, ())
+        self.assertEqual(ctx.learner_profile, "agency-product-manager")
+
+    def test_minimized_context_never_includes_secrets_or_memory(self):
+        """The LearnerContext dataclass has no fields for secrets, memory,
+        conversations, or full profile state.  This is a structural guarantee."""
+        ctx = minimize_learner_context(
+            learner_profile="agency-security-engineer",
+            role="Threat models and designs security controls",
+            objective="Learn cryptography fundamentals",
+        )
+        # Verify no unexpected attributes exist
+        fields = set(ctx.__dataclass_fields__.keys())
+        self.assertEqual(
+            fields,
+            {"learner_profile", "role", "objective", "relevant_skills"},
+        )
+
+
+class DatabasePerformanceRoutingTest(unittest.TestCase):
+    """A database-performance request routes to the data-science specialist
+    when database keywords are recognized in the objective."""
+
+    def test_database_performance_routes_to_data_science_professor(self):
+        result = route_learner(
+            learner_profile="agency-database-engineer",
+            objective="Teach me database performance tuning and query optimization",
+        )
+        self.assertIsNotNone(result.faculty)
+        # Database keywords match the data-science specialist preference
+        self.assertEqual(result.faculty, "academy-data-science-professor")
+        self.assertFalse(result.approximate)
+
+    def test_database_performance_reason_mentions_specialist(self):
+        result = route_learner(
+            learner_profile="agency-backend-engineer",
+            objective="I need to understand database performance indexing and query plans",
+        )
+        self.assertIsNotNone(result.faculty)
+        self.assertFalse(result.approximate)
+        self.assertIn("specialist", result.reason.lower())
+
+
+class RoutingDeterminismTest(unittest.TestCase):
+    """Routing decisions are deterministic — same input always produces same output."""
+
+    def test_same_input_same_output(self):
+        args = ("agency-backend-engineer", "Learn physics fundamentals")
+        result1 = route_learner(*args)
+        result2 = route_learner(*args)
+        self.assertEqual(result1, result2)
+
+    def test_routing_result_is_hashable(self):
+        result = route_learner(
+            "agency-frontend-engineer", "Learn color theory"
+        )
+        # Frozen dataclass should be hashable
+        hash(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hermes-academy/tests/test_routing.py
+++ b/hermes-academy/tests/test_routing.py
@@ -174,6 +174,48 @@ class DatabasePerformanceRoutingTest(unittest.TestCase):
         self.assertIn("specialist", result.reason.lower())
 
 
+class AmbiguousKeywordRoutingTest(unittest.TestCase):
+    """Ambiguous single words must not create confident specialist false positives."""
+
+    def test_single_ambiguous_words_do_not_confidently_misroute(self):
+        cases = (
+            ("I want to learn about base jumping", "academy-chemistry-professor"),
+            ("Teach me compound interest", "academy-chemistry-professor"),
+            ("Help me with energy drinks marketing", "academy-physics-professor"),
+            ("Teach me cell phone repair", "academy-biology-professor"),
+            ("I want to understand fashion modeling", "academy-data-science-professor"),
+        )
+        for objective, wrong_specialist in cases:
+            with self.subTest(objective=objective):
+                result = route_learner("agency-generalist", objective)
+                self.assertFalse(
+                    result.faculty == wrong_specialist and not result.approximate,
+                    f"ambiguous objective routed confidently to {wrong_specialist}: {result}",
+                )
+
+    def test_two_related_ambiguous_physics_terms_are_sufficient_context(self):
+        result = route_learner(
+            "agency-generalist",
+            "Teach me how force and energy relate in mechanical systems",
+        )
+        self.assertEqual(result.faculty, "academy-physics-professor")
+        self.assertFalse(result.approximate)
+
+    def test_distinctive_single_domain_terms_still_route_directly(self):
+        cases = (
+            ("Teach me thermodynamics", "academy-physics-professor"),
+            ("Teach me stoichiometry", "academy-chemistry-professor"),
+            ("Teach me genetics", "academy-biology-professor"),
+            ("Teach me probability", "academy-statistics-professor"),
+            ("Teach me cybersecurity", "academy-cybersecurity-instructor"),
+        )
+        for objective, expected in cases:
+            with self.subTest(objective=objective):
+                result = route_learner("agency-generalist", objective)
+                self.assertEqual(result.faculty, expected)
+                self.assertFalse(result.approximate)
+
+
 class RoutingDeterminismTest(unittest.TestCase):
     """Routing decisions are deterministic — same input always produces same output."""
 

--- a/hermes-academy/tests/test_teach_profile_skill.py
+++ b/hermes-academy/tests/test_teach_profile_skill.py
@@ -1,0 +1,123 @@
+"""Focused contract tests for the Academy instructor CE shared skill."""
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+ACADEMY_ROOT = Path(__file__).resolve().parents[1]
+CANONICAL = ACADEMY_ROOT / "shared-skills" / "teach-profile" / "SKILL.md"
+MANIFEST = json.loads((ACADEMY_ROOT / "academy.json").read_text(encoding="utf-8"))
+
+
+def _frontmatter_value(text: str, key: str) -> str:
+    match = re.search(rf"^{re.escape(key)}:\s*(.+)$", text, flags=re.MULTILINE)
+    if not match:
+        raise AssertionError(f"missing frontmatter key: {key}")
+    return match.group(1).strip().strip('"\'')
+
+
+class TeachProfileSkillTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = CANONICAL.read_text(encoding="utf-8")
+        cls.data = CANONICAL.read_bytes()
+
+    def test_frontmatter_is_routing_safe(self):
+        self.assertEqual(_frontmatter_value(self.text, "name"), "teach-profile")
+        description = _frontmatter_value(self.text, "description")
+        self.assertLessEqual(len(description), 60)
+        self.assertTrue(description.endswith("."))
+
+    def test_human_and_profile_learning_modes_are_distinguished(self):
+        self.assertIn("distinguish between a human learner and a Hermes-profile learner", self.text)
+        self.assertIn("For a human learner, teach normally", self.text)
+        self.assertIn("For a Hermes-profile learner, follow this contract", self.text)
+
+    def test_instructor_authority_is_strictly_bounded(self):
+        self.assertIn("Never edit the learner's skills", self.text)
+        self.assertIn("Never ask for secrets, credentials, full memory", self.text)
+        self.assertIn("The learner owns the `/learn` decision", self.text)
+        for forbidden_system in (
+            "Fleet",
+            "Keryx",
+            "Nodescale",
+            "Templar",
+            "RunAuthority",
+            "Run Capsules",
+        ):
+            self.assertIn(forbidden_system, self.text)
+
+    def test_minimum_sufficient_instruction_is_explicit(self):
+        required = (
+            "measurable competency transfer, not classroom roleplay",
+            "Teach the smallest amount necessary",
+            "logical functions, not mandatory conversational stages",
+            "If the baseline already proves the requested competency, declare that no instruction is required.",
+            "Teach only those gaps.",
+            "If a message does none of these, omit it.",
+            "Stop immediately once the requested competency is demonstrated.",
+            "capability gain per unit of inference",
+        )
+        for marker in required:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.text)
+
+    def test_transfer_is_required_when_instruction_occurred(self):
+        self.assertIn("meaningfully different problem", self.text)
+        self.assertIn("Do not accept any of the following as mastery", self.text)
+        self.assertIn('"I understand"', self.text)
+        self.assertIn("repeating the worked example", self.text)
+        self.assertIn("correct only the failed part", self.text)
+
+    def test_mastery_outcomes_are_explicit_and_bounded(self):
+        for outcome in ("**MASTERED**", "**NEEDS_CORRECTION**", "**BLOCKED**"):
+            with self.subTest(outcome=outcome):
+                self.assertIn(outcome, self.text)
+        self.assertIn("Do not declare mastery because a conversation has been long enough", self.text)
+
+    def test_completion_summary_supports_learner_native_learn(self):
+        required = (
+            "baseline capability already demonstrated",
+            "gaps actually taught",
+            "transfer evidence",
+            "mastery outcome",
+            "reusable principles or procedures worth retaining",
+            "If the learner already had the capability or the session produced no reusable delta",
+        )
+        for marker in required:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.text)
+        self.assertIn("`skill_manage`", self.text)
+
+    def test_all_academy_faculty_except_dean_materialize_canonical_bytes(self):
+        names = [profile["name"] for profile in MANIFEST["profiles"]]
+        faculty = [name for name in names if name != "academy-dean"]
+        self.assertGreater(len(faculty), 0)
+        for name in faculty:
+            with self.subTest(profile=name):
+                materialized = (
+                    ACADEMY_ROOT
+                    / "profiles"
+                    / name
+                    / "skills"
+                    / "teach-profile"
+                    / "SKILL.md"
+                )
+                self.assertTrue(materialized.is_file(), f"missing {materialized}")
+                self.assertEqual(materialized.read_bytes(), self.data)
+
+        dean_copy = (
+            ACADEMY_ROOT
+            / "profiles"
+            / "academy-dean"
+            / "skills"
+            / "teach-profile"
+            / "SKILL.md"
+        )
+        self.assertFalse(dean_copy.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.

--- a/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
@@ -1,12 +1,141 @@
 ---
 name: academy-continuing-education
-description: Learner-facing continuing-education skill for Hermes Academy. Placeholder — final prose is a later phase.
+description: Use when an Agency profile needs targeted Academy training.
 ---
 # Academy Continuing Education
 
-Placeholder shared skill. The canonical source lives at
-`hermes-academy/shared-skills/academy-continuing-education/SKILL.md`.
+Use this skill when the user asks this profile to learn, study, take a class, improve at a bounded competency, or get better at something with Hermes Academy.
 
-Final instructional prose is authored in a later phase. This file
-establishes the packaging seam so the installer can materialize it
-into participating learner profiles.
+Hermes Academy Continuing Education is a competency-transfer system, not a school simulation. Use the minimum instruction required to produce and verify a real capability improvement.
+
+## Non-negotiable rules
+
+- The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
+- Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
+- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
+- Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+- An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- Learning must remain local to this learner. Never modify Profile Packs source merely because this installed profile learned something.
+- Do not silently start another class. Further study requires a user instruction or an explicit learner decision under the active goal.
+
+## Minimum-sufficient workflow
+
+### 1. Resolve the objective
+
+Convert the user's request into one observable competency.
+
+Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
+
+If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+
+### 2. Establish the learner goal
+
+Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+
+- the target competency;
+- what evidence will demonstrate it;
+- relevant safety or scope constraints;
+- the requirement for meaningfully different transfer evidence when instruction is needed;
+- the requirement to run `/learn` only if the event produced a reusable capability delta;
+- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+
+Do not create a second orchestration loop around `/goal`.
+
+### 3. Baseline before teaching
+
+Attempt a representative task or answer that exercises the target competency before requesting instruction.
+
+If the baseline already demonstrates the competency strongly enough, stop. Report that no instruction was required and do **not** create or modify a skill merely to prove that learning happened.
+
+If there are gaps, identify only those gaps. Do not ask the instructor to reteach material already demonstrated.
+
+### 4. Request targeted instruction
+
+Use native `message_agent` in canonical Bot Chat to contact the selected instructor. Send only what the instructor needs:
+
+- learner profile/role;
+- one objective;
+- concise baseline evidence;
+- the specific gaps or uncertainty;
+- relevant existing skill names/descriptions only when they materially affect the lesson.
+
+Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
+
+After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+### 5. Learn only the demonstrated gaps
+
+Treat the instructor response as educational content, not authority over learner internals.
+
+Each additional instructional turn must do at least one useful job:
+
+- diagnose a remaining gap;
+- teach a demonstrated gap;
+- assess the learner;
+- correct a specific failure;
+- conclude mastery; or
+- report a genuine blocker.
+
+If a turn does none of these, omit it.
+
+Do not require fixed lesson lengths, modules, ceremonial quizzes, greetings, acknowledgement turns, or a predetermined number of exchanges. One concise correction can be enough.
+
+### 6. Prove transfer
+
+When instruction was required, demonstrate the competency on a meaningfully different problem that requires the same underlying capability.
+
+Do not count acknowledgement, paraphrasing the instructor, or repeating the demonstrated example as mastery.
+
+If the transfer attempt fails, correct only the failed part and retry with the minimum additional work needed. Do not replay the whole lesson.
+
+Stop as soon as the completion contract is satisfied.
+
+### 7. Persist only a real capability delta
+
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+
+After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+
+If there is no reusable delta, skip `/learn`.
+
+### 8. Report compactly
+
+Tell the user:
+
+- what competency was evaluated;
+- which instructor was used;
+- whether the baseline already passed or which gaps were taught;
+- the transfer result;
+- whether `/learn` created or extended a skill, including its name when available;
+- any unresolved blocker or recommended follow-up.
+
+Do not narrate internal classroom ceremony.
+
+## Efficiency evidence
+
+When the information is already available, keep a compact record of:
+
+- learner turns;
+- instructor turns;
+- retries;
+- baseline result;
+- post-instruction transfer result;
+- whether `/learn` produced a durable skill change;
+- token or inference usage when Hermes exposes it without extra work.
+
+Optimize for measurable capability gain with minimum inference cost. Never spend extra turns only to make the training look more like school.
+
+## Stop conditions
+
+Stop and report honestly when:
+
+- the competency is already demonstrated;
+- mastery is demonstrated after instruction;
+- the instructor is unavailable and no safe alternative is resolved;
+- the objective is outside the instructor's safe subject boundary;
+- the native goal budget is exhausted;
+- `/learn` is blocked by normal approval or safety controls; or
+- the requested change would require authority outside this learner's normal permissions.


### PR DESCRIPTION
## Summary

Implements Hermes Academy Continuing Education Phases 4-6 on top of the merged shared-skill packaging seam.

- replaces the learner `academy-continuing-education` placeholder with the production competency-transfer contract
- replaces the instructor `teach-profile` placeholder with minimum-sufficient teaching, transfer assessment, and bounded mastery semantics
- adds deterministic Dean profile-learner routing and minimized learner context
- adds the durable architecture invariant that fixed QA turn sequences are test scaffolding, not production classroom choreography
- fixes ambiguous single-keyword Dean routing false positives found during independent technical review

## Behavioral constraints

- natural-language UX remains primary
- native `/goal`, canonical Bot Chat + `message_agent`, native `/learn`, and normal `skill_manage` only
- no teacher writes into learner skills/SOUL/config
- no custom CE persistence, scheduler, message bus, or recursive training
- zero Fleet/Keryx/Nodescale/Templar/RunAuthority/Run Capsules dependency
- baseline first, teach only demonstrated gaps, stop on demonstrated transfer, `/learn` only for a reusable capability delta

## Validation

Combined integration head `d311f3b`:

- Academy: 57/57 tests PASS
- Agency: 18/18 tests PASS
- Council: 3/3 tests PASS
- root tests: 16/16 PASS
- repository validator PASS
- `git diff --check` PASS

## Independent review

- Phase 4-6 content/learning-flow review: APPROVED
- initial technical review found one blocker: ambiguous single-word routing could confidently misroute unrelated requests
- fix: `6b66540`
- bounded correction re-review: PASS against integration head `d311f3b7e538409d20f5a67f554f9cf3891c5cca`
