### PR TITLE
feat(academy): bind Continuing Education to native Hermes goal and learn flow

### DIFF
--- a/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
+++ b/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-academy/tests/test_native_classroom_flow.py
+++ b/hermes-academy/tests/test_native_classroom_flow.py
@@ -1,0 +1,161 @@
+"""Phase 7-9 contract tests for native Academy classroom orchestration."""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ACADEMY_ROOT = Path(__file__).resolve().parents[1]
+LEARNER_SKILL = ACADEMY_ROOT / "shared-skills" / "academy-continuing-education" / "SKILL.md"
+INSTRUCTOR_SKILL = ACADEMY_ROOT / "shared-skills" / "teach-profile" / "SKILL.md"
+
+
+class NativeGoalContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.learner = LEARNER_SKILL.read_text(encoding="utf-8")
+        cls.instructor = INSTRUCTOR_SKILL.read_text(encoding="utf-8")
+
+    def test_real_native_goal_and_subgoal_handlers_are_required(self):
+        self.assertIn("actual native `/goal` handler", self.learner)
+        self.assertIn("native `/subgoal`", self.learner)
+        self.assertIn("never imitate their loop, persistence, approval, or completion logic", self.learner)
+        self.assertIn("Do not create a second orchestration loop around `/goal` or `/subgoal`", self.learner)
+
+    def test_completion_contract_inputs_are_explicit(self):
+        for marker in (
+            "this learner's profile/role",
+            "the target competency",
+            "the selected instructor",
+            "domain-appropriate evidence",
+            "budget-exhausted",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.learner)
+
+    def test_subgoal_is_only_for_new_required_deficiency(self):
+        self.assertIn("new required deficiency", self.learner)
+        self.assertIn("Do not create subgoals for routine corrections", self.learner)
+
+    def test_goal_budget_never_becomes_false_success(self):
+        self.assertIn("normal bounded goal budget", self.learner)
+        self.assertIn(
+            "Training paused because the learning objective has not yet been demonstrated.",
+            self.learner,
+        )
+        self.assertIn("Never convert budget exhaustion into success", self.learner)
+
+
+class NativeClassroomLoopTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.learner = LEARNER_SKILL.read_text(encoding="utf-8")
+        cls.instructor = INSTRUCTOR_SKILL.read_text(encoding="utf-8")
+
+    def test_transport_is_native_message_agent_and_peer_wait(self):
+        self.assertIn("native `message_agent` in canonical Bot Chat", self.learner)
+        self.assertIn("native `/goal` peer-wait behavior", self.learner)
+        self.assertIn("Do not send duplicate requests", self.learner)
+        self.assertIn("burn turns", self.learner)
+
+    def test_no_acknowledgement_ping_pong(self):
+        self.assertIn("acknowledgement turns", self.learner)
+        self.assertIn("acknowledgement ping-pong", self.instructor)
+        self.assertIn("If a message does none of these, omit it", self.instructor)
+
+    def test_user_visibility_is_concise_not_chatty(self):
+        self.assertIn("Keep user-visible status concise", self.learner)
+        self.assertIn("Do not narrate every Bot message", self.learner)
+        self.assertIn("Learning: Backend Engineer → API security with Cybersecurity Instructor.", self.learner)
+
+    def test_user_can_interrupt_or_change_objective(self):
+        for marker in (
+            "Stop the class",
+            "Focus more on OAuth",
+            "Also teach token rotation",
+            "native goal/preemption behavior",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.learner)
+
+    def test_every_instructor_message_has_a_job(self):
+        for marker in (
+            "diagnose a remaining gap",
+            "teach a demonstrated gap",
+            "assess application",
+            "correct a specific failure",
+            "conclude mastery",
+            "report a genuine blocker",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.instructor)
+
+
+class NativeLearnHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.learner = LEARNER_SKILL.read_text(encoding="utf-8")
+        cls.instructor = INSTRUCTOR_SKILL.read_text(encoding="utf-8")
+
+    def test_learn_happens_only_after_real_transfer(self):
+        self.assertIn("meaningfully different problem", self.learner)
+        self.assertIn("Stop as soon as the completion contract is satisfied", self.learner)
+        self.assertIn("If there is no reusable delta, skip `/learn`", self.learner)
+        self.assertIn("including transfer when instruction was required", self.instructor)
+
+    def test_write_approval_is_never_bypassed(self):
+        self.assertIn("`skills.write_approval`", self.learner)
+        self.assertIn("normal Hermes approval boundary", self.learner)
+        self.assertIn("Never bypass, auto-approve, or weaken it", self.learner)
+
+    def test_create_and_extend_are_both_native_outcomes(self):
+        self.assertIn("matching skill was **extended**", self.learner)
+        self.assertIn("new skill was **created**", self.learner)
+        self.assertIn("Prefer extension when native `/learn` identifies an existing relevant skill", self.learner)
+        self.assertIn("Do not preselect or force the outcome in Academy logic", self.learner)
+
+    def test_result_verification_is_complete(self):
+        for marker in (
+            "skill name",
+            "purpose",
+            "learner-profile location",
+            "reusable behavior, procedure, or decision criteria",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.learner)
+
+    def test_teacher_never_writes_the_skill(self):
+        self.assertIn("The instructor must never write the skill", self.learner)
+        self.assertIn("The learner owns the `/learn` decision", self.instructor)
+
+
+class NoParallelRuntimeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.learner = LEARNER_SKILL.read_text(encoding="utf-8")
+
+    def test_no_parallel_academy_runtime_is_introduced(self):
+        for marker in (
+            "Do not create a scheduler",
+            "training database",
+            "candidate-skill registry",
+            "parallel memory store",
+            "alternate message bus",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.learner)
+
+    def test_forbidden_distributed_dependencies_remain_forbidden(self):
+        for marker in (
+            "Fleet",
+            "Keryx",
+            "Nodescale",
+            "Templar",
+            "RunAuthority",
+            "Run Capsules",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.learner)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 

--- a/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,16 +31,22 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Use native `/goal` for the learner-authoritative completion contract. The goal should include:
+Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
 
+- this learner's profile/role;
 - the target competency;
-- what evidence will demonstrate it;
+- the selected instructor;
+- what domain-appropriate evidence will demonstrate the competency;
 - relevant safety or scope constraints;
 - the requirement for meaningfully different transfer evidence when instruction is needed;
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
-- a stop condition for mastered, blocked, or unavailable-instructor outcomes.
+- a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-Do not create a second orchestration loop around `/goal`.
+If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+Do not create a second orchestration loop around `/goal` or `/subgoal`.
 
 ### 3. Baseline before teaching
 
@@ -63,6 +69,10 @@ Use native `message_agent` in canonical Bot Chat to contact the selected instruc
 Do not send full memory, unrelated conversations, secrets, credentials, or broad profile state.
 
 After `message_agent` starts an outstanding instructor reply, allow native `/goal` peer-wait behavior to park the goal. Do not send duplicate requests, poll conversationally, burn turns, or declare success while waiting.
+
+Keep user-visible status concise. At the start, one compact line is enough, for example: `Learning: Backend Engineer → API security with Cybersecurity Instructor.` After that, surface only meaningful changes such as a corrected gap, changed objective, blocker, approval request, or completion. Do not narrate every Bot message.
+
+The user remains in control of the active goal. Normal Hermes messages may interrupt or change it. Requests such as `Stop the class`, `Focus more on OAuth`, or `Also teach token rotation` must be handled through native goal/preemption behavior rather than ignored until the original flow finishes. Stop when asked; when focus changes, update the active objective/criteria instead of silently starting a recursive second class.
 
 ### 5. Learn only the demonstrated gaps
 
@@ -95,9 +105,19 @@ Stop as soon as the completion contract is satisfied.
 
 If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
 
-Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. Respect normal approval and safety behavior.
+Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
-After `/learn`, verify that the expected skill was created or extended in this learner's normal skill store. Do not ask the instructor to write it. Do not modify Academy or Agency source distributions.
+After `/learn`, use normal skill inspection to verify the result. Confirm:
+
+- skill name;
+- whether a matching skill was **extended** or a new skill was **created**;
+- purpose;
+- learner-profile location;
+- the reusable behavior, procedure, or decision criteria that were captured.
+
+Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 
 If there is no reusable delta, skip `/learn`.
 


### PR DESCRIPTION
## Summary

Implements Hermes Academy Continuing Education Phases 7-9 as a thin native-Hermes contract layer.

- invokes the actual native `/goal` and `/subgoal` model rather than copying orchestration logic
- reuses canonical Bot Chat + native `message_agent` and the already-proven native goal peer-wait behavior
- adds concise user visibility and normal Hermes interruption/objective-change semantics
- makes budget exhaustion fail honestly instead of becoming false mastery
- binds durable learning to native `/learn` + `skill_manage`
- explicitly respects `skills.write_approval`
- verifies native create-vs-extend outcomes, skill purpose/location, and captured reusable behavior
- adds deterministic Phase 7-9 contract tests

No Academy scheduler, state machine, persistence store, message bus, runtime service, or Hermes-core change is introduced.

## Validation

Commit: `b924bbc`

- focused Phase 4-9/shared-skill tests: 49/49 PASS
- Academy: 73/73 PASS
- Agency: 18/18 PASS
- Council: 3/3 PASS
- root: 16/16 PASS
- repository validator PASS
- `git diff --check` PASS
- disposable `HERMES_HOME` profile install PASS; installed CE skill SHA-256 matched canonical source exactly

## Native source review

Verified against current Hermes Agent source:

- `/goal` user-message preemption and bounded goal behavior are native
- `/subgoal` is implemented by the native GoalManager/CLI path
- `/learn` inventories existing skills, extends matches first, and creates only when no match exists
- `skills.write_approval` is a real CLI/gateway write gate
- Phase 3 already proved native message-agent peer wait and concluded `NO CORE CHANGE`

Operator review: PASS.
