### PR TITLE
docs(academy): harden CE learner persistence and refresh documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Hermes Profile Packs will be documented here.
 
 ### Added
 
+- Added the merged Hermes Academy Continuing Education foundation through the Phase 10–13 quality gate: canonical learner/instructor shared skills, Dean routing, native Bot Chat + `message_agent` teaching transport, native `/goal`/`/subgoal`/`/learn` contracts, minimum-sufficient competency transfer, and deterministic/native-runtime regression coverage. Controlled Phase 14/15 capability validation is still pending before production-readiness claims.
+- Added `docs/CONTINUING_EDUCATION.md` as the current behavior/status guide and updated the normative architecture contract with the selected transport and learner-skill preservation invariant.
 - Integrated Team Recipes into the canonical root `install.py` wizard and agent/script interface, including direct recipe browsing, `--list-recipes`, `--recipe`, and `--tier` selection.
 - Added confidence-aware recipe promotion: a recipe must clear both a minimum score and a minimum lead over alternatives before the installer presents it as a clear match; ambiguous goals fall back to individual profiles.
 - Added additive `recipe_match` and `recipe_recommendations` fields to `--recommend --json` while preserving the existing individual-profile `recommendations` contract.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ The packs deliberately separate durable context domains. Agency executes profess
 
 Hermes Council currently contains 21 focused profiles and 84 purpose-built personal-life skills. Hermes Academy v0.2 contains 30 faculty profiles and 120 purpose-built teaching skills. Hermes Agency contains 109 professional specialists.
 
+### Academy Continuing Education
+
+Hermes Academy also includes an in-progress Continuing Education flow for profile-to-profile competency transfer. The merged implementation uses natural-language requests, Dean routing when needed, native `/goal`, canonical Bot Chat + `message_agent`, Academy instruction/transfer assessment, and native `/learn` into the learner's normal skill store. It adds no custom training runtime or Fleet dependency.
+
+Implementation and deterministic/native-runtime validation are complete through the Phase 10–13 quality gate. Controlled real-world capability preflight is still in progress, so Continuing Education should not yet be described as production-validated. See [`docs/CONTINUING_EDUCATION.md`](docs/CONTINUING_EDUCATION.md) and the normative [`docs/CONTINUING_EDUCATION_ARCHITECTURE.md`](docs/CONTINUING_EDUCATION_ARCHITECTURE.md).
+
 ## Start small with Team Recipes
 
 You rarely need all 160 profiles. Team Recipes are validated compositions of existing profiles for common outcomes, with `minimal`, `recommended`, and `expanded` tiers.

--- a/docs/CONTINUING_EDUCATION.md
+++ b/docs/CONTINUING_EDUCATION.md
@@ -1,0 +1,78 @@
+# Hermes Academy Continuing Education
+
+Status: **implemented through the Phase 10–13 quality gate; controlled real-world preflight is still in progress.** Do not describe Continuing Education as production-validated until the Phase 14/15 capability tests pass.
+
+Hermes Academy Continuing Education lets an installed Hermes profile learn a bounded reusable capability from Academy faculty without introducing a second agent runtime, scheduler, memory system, or skill database.
+
+## What is implemented
+
+The current merged flow uses normal Hermes primitives:
+
+1. A learner receives a natural-language request such as `Go learn API security.`
+2. If the user did not name a teacher, `academy-dean` routes to the most specific installed faculty member.
+3. The learner uses the native `/goal` system for the completion contract.
+4. One-to-one teaching uses canonical Bot Chat + native `message_agent`.
+5. The instructor baselines the requested competency, teaches only demonstrated gaps, and requires meaningfully different transfer evidence when instruction was needed.
+6. Native goal peer-wait parks while an instructor reply is outstanding instead of burning turns or sending duplicate requests.
+7. The learner invokes native `/learn` only when the session produced a reusable capability delta.
+8. Hermes' normal `skill_manage` path extends a relevant learner skill or creates a new learner-local skill.
+9. The learner verifies the resulting skill and confirms unrelated pre-existing skills were preserved.
+
+Native Bot groups are a validated optional group-learning surface, but they are not the default Continuing Education transport.
+
+## User experience
+
+Users should not need to know about slash commands or Bot internals. Typical requests are ordinary language:
+
+```text
+Go learn API security.
+Get better at database performance with Academy.
+Study statistical experiment design.
+Learn this from the Cybersecurity Instructor.
+```
+
+Normal status messages stay compact, for example:
+
+```text
+Learning API security with Cybersecurity Instructor.
+Working on a gap in authorization-boundary reasoning.
+Continuing education complete: transfer assessment passed; updated auth-boundary-review.
+```
+
+`School for Bots` is a useful informal description of the idea, not the runtime protocol. Production behavior is minimum-sufficient competency transfer, not classroom roleplay or fixed lesson lengths.
+
+## Safety and authority boundaries
+
+- Instructors teach and assess. They never directly edit learner skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
+- The learner owns the `/learn` decision and the resulting skill write.
+- `skills.write_approval` remains authoritative when enabled.
+- Before `/learn`, the learner records its current skills. `/learn` may extend one relevant skill or create one new skill, but unrelated skills must remain present. Unexpected skill loss fails the CE event closed.
+- Source Profile Packs are read-only during local learning. Learned behavior remains local to the learner unless a separate human-controlled contribution process upstreams it later.
+- One class cannot silently launch another. Further study requires a user request or an explicit learner decision under the active goal.
+- Existing Academy subject/safety boundaries remain in force.
+- Continuing Education has zero runtime dependency on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
+
+## Current validation evidence
+
+Before the controlled real-world preflight, the merged implementation has already passed:
+
+- canonical `message_agent` transport validation and real multi-turn teaching evidence;
+- native goal peer-wait verification with `NO CORE CHANGE` as the Phase 3 seam decision;
+- learner-only native skill-placement proof;
+- shared-skill packaging and byte-identity validation;
+- Dean routing tests, including ambiguous-keyword false-positive regressions;
+- security/trust review with permanent adversarial tests;
+- native Hermes goal/subgoal, Bot Chat, `/learn`, skill-manager, write-approval, restart/resume, and canonical-session tests against a disposable Hermes home;
+- repository, Agency, Council, and Academy validation with no Fleet dependency.
+
+The Phase 14 controlled preflight must still prove persistent capability improvement in a fresh learner session. An earlier Phase 14 attempt is not accepted because it used an outdated learner distribution that did not contain the CE learner skill and bypassed the complete merged flow.
+
+## Source locations
+
+- Learner skill: `hermes-academy/shared-skills/academy-continuing-education/SKILL.md`
+- Instructor skill: `hermes-academy/shared-skills/teach-profile/SKILL.md`
+- Dean routing: `hermes-academy/routing.py`
+- Architecture contract: `docs/CONTINUING_EDUCATION_ARCHITECTURE.md`
+- Academy manifest: `hermes-academy/academy.json`
+
+The Academy installer materializes the canonical shared skills into their participating profile distributions; validators enforce byte identity so contributors edit the canonical source rather than divergent copies.

--- a/docs/CONTINUING_EDUCATION_ARCHITECTURE.md
+++ b/docs/CONTINUING_EDUCATION_ARCHITECTURE.md
@@ -1,11 +1,6 @@
 # Hermes Academy Continuing Education — Architecture Contract
 
-Status: Phase 0 (frozen). This document is the normative, short architecture
-contract for Hermes Academy Continuing Education. It freezes the actors,
-hard invariants, and naming decisions so later phases (1–16 of the master
-plan) cannot quietly balloon into a new framework. Later phases implement
-against this contract; they do not amend it except through an explicit,
-documented change to this file.
+Status: normative architecture contract; implementation is merged through Phase 13 and Phase 14 controlled preflight is pending final acceptance. This document freezes the actors, hard invariants, transport decision, and naming decisions so later work cannot quietly balloon into a new framework. Changes to these decisions require an explicit, documented edit here.
 
 ## Scope independence
 
@@ -85,14 +80,21 @@ the constraints for every later phase.
     reusable capability delta worth persisting. Phase-specific QA scripts may
     use fixed turn sequences to prove mechanics, but those sequences are test
     scaffolding and must not become the production teaching protocol.
+12. **Learner skill preservation.** Before native `/learn`, record the learner's
+    existing skill names. The persistence request may extend one relevant skill
+    or create one new skill, but it must preserve unrelated learner skills.
+    After `/learn`, verify every unrelated pre-existing skill still exists. Any
+    unexplained loss, relocation, or overwrite fails the Continuing Education
+    event closed; do not report successful learning until recovery is complete.
 
-## Transport decision (deferred)
+## Transport decision (selected)
 
-The classroom transport must be a **native Bot Mode** conversation
-mechanism. The specific choice — canonical Bot Chat + `message_agent`
-(Preferred A) versus a native Bot Mode group classroom (Alternative B) —
-is selected by the later Phase 2 experiments. This contract only requires
-that the mechanism be native Hermes Bot Mode; no new message bus is built.
+The canonical one-to-one classroom transport is **canonical Bot Chat + native
+`message_agent`**. Phase 2 proved sender validation/attribution, asynchronous
+delivery, recipient wake-up, canonical history persistence/ordering, and a
+multi-turn instructional exchange. Native Bot groups were also validated as a
+useful optional group/classroom surface, but they are not the default CE
+transport. No new message bus is built.
 
 ## Naming decisions (frozen)
 

--- a/hermes-academy/ACADEMY.md
+++ b/hermes-academy/ACADEMY.md
@@ -18,6 +18,8 @@ When useful, Academy faculty should follow this loop:
 
 Do not mechanically force every step into every answer. Match the interaction to the learner.
 
+For Hermes-profile Continuing Education, this loop is a set of instructional functions, not a mandatory turn sequence. Baseline first, teach only demonstrated gaps, require transfer when instruction was needed, and stop as soon as competency is demonstrated. The learner owns native `/goal` and `/learn`; faculty never write learner skills directly. See `../docs/CONTINUING_EDUCATION.md`.
+
 ## Direct-answer mode
 
 If the learner asks for a concise fact, calculation, definition, or direct explanation, answer it. Academy is not allowed to become irritating in the name of pedagogy.

--- a/hermes-academy/README.md
+++ b/hermes-academy/README.md
@@ -8,6 +8,14 @@ Opening an Academy profile should feel like walking into the office, classroom, 
 
 Academy v0.2 contains **30 faculty profiles and 120 purpose-built teaching skills**. It keeps broad chairs for interdisciplinary learning while adding dedicated specialists for subjects that benefit from deeper routing.
 
+## Continuing Education
+
+Academy can also teach another installed Hermes profile through the Continuing Education flow. A learner can receive an ordinary request such as `Go learn API security`, route through `academy-dean` when needed, use native Hermes goal/Bot/learning primitives underneath, and persist a reusable capability in its own normal skill store.
+
+The implementation is merged and validated through the Phase 10–13 quality gate, but the controlled persistent-capability preflight is still in progress. Treat this as **pre-release/experimental**, not yet production-validated. See [`../docs/CONTINUING_EDUCATION.md`](../docs/CONTINUING_EDUCATION.md) for current behavior and status.
+
+Continuing Education is minimum-sufficient competency transfer, not a fixed classroom simulation. Instructors teach and assess; the learner owns `/learn` and all learner-local persistence. Canonical one-to-one transport is Bot Chat + `message_agent`, and there is no Fleet dependency.
+
 ## Faculty
 
 | Profile | Teaching domain |

--- a/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
+++ b/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-academy/tests/test_ce_skill_preservation.py
+++ b/hermes-academy/tests/test_ce_skill_preservation.py
@@ -1,0 +1,45 @@
+"""Regression tests for CE learner-skill preservation and current docs."""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = ROOT.parent
+LEARNER = (ROOT / "shared-skills" / "academy-continuing-education" / "SKILL.md").read_text(encoding="utf-8")
+ARCH = (REPO / "docs" / "CONTINUING_EDUCATION_ARCHITECTURE.md").read_text(encoding="utf-8")
+GUIDE = (REPO / "docs" / "CONTINUING_EDUCATION.md").read_text(encoding="utf-8")
+
+
+class LearnerSkillPreservationTests(unittest.TestCase):
+    def test_inventory_before_learn_is_required(self):
+        self.assertIn("Before `/learn`, record the learner's current skill names", LEARNER)
+
+    def test_unrelated_skills_must_be_preserved(self):
+        self.assertIn("preserve every unrelated existing skill", LEARNER)
+        self.assertIn("must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills", LEARNER)
+
+    def test_post_learn_verifies_unrelated_skills(self):
+        self.assertIn("every unrelated skill recorded before `/learn` still exists afterward", LEARNER)
+
+    def test_skill_loss_fails_closed(self):
+        self.assertIn("fails closed", LEARNER)
+        self.assertIn("Do not report successful learning", LEARNER)
+
+    def test_architecture_has_preservation_invariant(self):
+        self.assertIn("**Learner skill preservation.**", ARCH)
+        self.assertIn("unexplained loss, relocation, or overwrite fails the Continuing Education", ARCH.replace("\n", " "))
+
+    def test_transport_is_no_longer_documented_as_deferred(self):
+        self.assertIn("## Transport decision (selected)", ARCH)
+        self.assertIn("canonical Bot Chat + native", ARCH)
+        self.assertNotIn("## Transport decision (deferred)", ARCH)
+
+    def test_user_guide_is_truthful_about_preflight(self):
+        self.assertIn("controlled real-world preflight is still in progress", GUIDE)
+        self.assertIn("Do not describe Continuing Education as production-validated", GUIDE)
+        self.assertIn("earlier Phase 14 attempt is not accepted", GUIDE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 

--- a/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
@@ -103,7 +103,9 @@ Stop as soon as the completion contract is satisfied.
 
 ### 7. Persist only a real capability delta
 
-If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, invoke native `/learn` from the learner.
+If the session produced reusable knowledge, procedure, heuristics, or decision criteria that should improve future work, prepare for native `/learn` from the learner.
+
+Before `/learn`, record the learner's current skill names. The persistence request must explicitly preserve every unrelated existing skill: `/learn` may extend one relevant skill or create one new skill, but it must not delete, consolidate, rename, relocate, or overwrite unrelated learner skills.
 
 Let the normal Hermes learning path use `skill_manage` to create or extend the learner-local skill. If `skills.write_approval` is enabled, stop at the normal Hermes approval boundary and surface that approval request. Never bypass, auto-approve, or weaken it because Academy initiated the learning.
 
@@ -113,9 +115,12 @@ After `/learn`, use normal skill inspection to verify the result. Confirm:
 - whether a matching skill was **extended** or a new skill was **created**;
 - purpose;
 - learner-profile location;
-- the reusable behavior, procedure, or decision criteria that were captured.
+- the reusable behavior, procedure, or decision criteria that were captured;
+- every unrelated skill recorded before `/learn` still exists afterward.
 
 Both outcomes are valid. Prefer extension when native `/learn` identifies an existing relevant skill; otherwise allow normal `/learn` to create one. Do not preselect or force the outcome in Academy logic.
+
+If any unrelated pre-existing learner skill disappeared or moved unexpectedly, the Continuing Education event **fails closed**. Do not report successful learning. Surface the unexpected skill loss, preserve evidence, and require recovery before continuing.
 
 Do not ask the instructor to write it. The instructor must never write the skill. Do not modify Academy or Agency source distributions.
 


### PR DESCRIPTION
## Summary

Hardens Hermes Academy Continuing Education before the controlled Phase 14 rerun and refreshes public documentation to match the actually merged system.

- records learner skills before native /learn
- explicitly requires /learn to preserve unrelated skills
- fails CE closed if an unrelated pre-existing skill disappears, moves, or is overwritten
- rematerializes the canonical learner skill into all participating Agency distributions
- updates the normative architecture contract with the selected Bot Chat + message_agent transport and learner-skill preservation invariant
- adds docs/CONTINUING_EDUCATION.md with truthful current status: implementation merged through Phase 13, controlled capability preflight still pending
- updates root README, Academy README/teaching contract, and changelog
- adds preservation/documentation regression tests

## Phase 14 bug adjudication

The earlier HIGH skill-loss claim was not reproducible against current native Hermes. Controlled reproduction showed:

- clone preserved all 21 Backend Engineer skills
- normal Hermes startup preserved all 21
- native skill_manage(create) preserved all existing skills
- real native /learn preserved all 21 and added one new skill

The earlier Phase 14 attempt used a learner distribution that did not contain academy-continuing-education and manually/directly routed teaching, so it was not a valid test of the merged CE path.

## Validation

- Academy: 180 tests PASS (1 opt-in native-runtime test skipped without HERMES_AGENT_SOURCE)
- Agency: 18 PASS
- Council: 3 PASS
- root: 16 PASS
- repository validator PASS
- git diff --check PASS
