### PR TITLE
feat(academy): bind CE goals through native Bot bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Hermes Profile Packs will be documented here.
 
 ### Added
 
-- Added the merged Hermes Academy Continuing Education foundation through the Phase 10–13 quality gate: canonical learner/instructor shared skills, Dean routing, native Bot Chat + `message_agent` teaching transport, native `/goal`/`/subgoal`/`/learn` contracts, minimum-sufficient competency transfer, and deterministic/native-runtime regression coverage. Controlled Phase 14/15 capability validation is still pending before production-readiness claims.
+- Added the merged Hermes Academy Continuing Education foundation through the Phase 10–13 quality gate: canonical learner/instructor shared skills, Dean routing, native Bot Chat + `message_agent` teaching transport, native `/goal`/`/subgoal`/`/learn` contracts, minimum-sufficient competency transfer, and deterministic/native-runtime regression coverage. Phase 14 v3 then proved natural-language Bot learning needed a generic agent-to-GoalManager seam; CE now uses the Bot-Chat-only `goal_manage` bridge merged in downstream Hermes PR #24. Controlled Phase 14/15 capability validation is still pending before production-readiness claims.
 - Added `docs/CONTINUING_EDUCATION.md` as the current behavior/status guide and updated the normative architecture contract with the selected transport and learner-skill preservation invariant.
 - Integrated Team Recipes into the canonical root `install.py` wizard and agent/script interface, including direct recipe browsing, `--list-recipes`, `--recipe`, and `--tier` selection.
 - Added confidence-aware recipe promotion: a recipe must clear both a minimum score and a minimum lead over alternatives before the installer presents it as a clear match; ambiguous goals fall back to individual profiles.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Hermes Council currently contains 21 focused profiles and 84 purpose-built perso
 
 ### Academy Continuing Education
 
-Hermes Academy also includes an in-progress Continuing Education flow for profile-to-profile competency transfer. The merged implementation uses natural-language requests, Dean routing when needed, native `/goal`, canonical Bot Chat + `message_agent`, Academy instruction/transfer assessment, and native `/learn` into the learner's normal skill store. It adds no custom training runtime or Fleet dependency.
+Hermes Academy also includes an in-progress Continuing Education flow for profile-to-profile competency transfer. The merged implementation uses natural-language requests, Dean routing when needed, canonical Bot Chat, the generic `goal_manage` bridge into Hermes' native `/goal` state, `message_agent`, Academy instruction/transfer assessment, and native `/learn` into the learner's normal skill store. It adds no custom training runtime or Fleet dependency.
 
-Implementation and deterministic/native-runtime validation are complete through the Phase 10–13 quality gate. Controlled real-world capability preflight is still in progress, so Continuing Education should not yet be described as production-validated. See [`docs/CONTINUING_EDUCATION.md`](docs/CONTINUING_EDUCATION.md) and the normative [`docs/CONTINUING_EDUCATION_ARCHITECTURE.md`](docs/CONTINUING_EDUCATION_ARCHITECTURE.md).
+Implementation and deterministic/native-runtime validation are complete through the Phase 10–13 quality gate. Controlled real-world capability preflight is still in progress, so Continuing Education should not yet be described as production-validated. The current preflight requires a Hermes build containing the generic Bot Chat `goal_manage` bridge (merged in `Dadmin88/hermes-agent-downstream` PR #24); stock-install readiness remains a release gate until equivalent support is present in the normal Hermes release. See [`docs/CONTINUING_EDUCATION.md`](docs/CONTINUING_EDUCATION.md) and the normative [`docs/CONTINUING_EDUCATION_ARCHITECTURE.md`](docs/CONTINUING_EDUCATION_ARCHITECTURE.md).
 
 ## Start small with Team Recipes
 

--- a/docs/CONTINUING_EDUCATION.md
+++ b/docs/CONTINUING_EDUCATION.md
@@ -10,7 +10,7 @@ The current merged flow uses normal Hermes primitives:
 
 1. A learner receives a natural-language request such as `Go learn API security.`
 2. If the user did not name a teacher, `academy-dean` routes to the most specific installed faculty member.
-3. The learner uses the native `/goal` system for the completion contract.
+3. In canonical Bot Chat, the learner uses `goal_manage(action="set", ...)` to establish the current session's real native `/goal`/`GoalContract` state. `goal_manage` is only a thin bridge to Hermes' existing GoalManager; it is not an Academy scheduler or replacement loop.
 4. One-to-one teaching uses canonical Bot Chat + native `message_agent`.
 5. The instructor baselines the requested competency, teaches only demonstrated gaps, and requires meaningfully different transfer evidence when instruction was needed.
 6. Native goal peer-wait parks while an instructor reply is outstanding instead of burning turns or sending duplicate requests.
@@ -19,6 +19,12 @@ The current merged flow uses normal Hermes primitives:
 9. The learner verifies the resulting skill and confirms unrelated pre-existing skills were preserved.
 
 Native Bot groups are a validated optional group-learning surface, but they are not the default Continuing Education transport.
+
+## Current Hermes compatibility
+
+The Phase 14 v3 preflight proved that native goal **peer-wait** already worked once a goal existed, but natural-language Bot learning still lacked a safe way for the agent itself to establish that standing goal. The generic Bot-Chat-only `goal_manage` bridge now fills that seam by calling the existing Hermes `GoalManager` directly.
+
+The bridge is merged in the maintained downstream Hermes Agent as PR #24 / merge `9b8de86a80`. It exposes only `set`, `status`, and `add_subgoal`; it cannot replace, pause, resume, clear, or target another session's goal. Until equivalent support is present in the normal Hermes release used by Profile Packs, Continuing Education remains pre-release and must not be described as stock-install production ready.
 
 ## User experience
 
@@ -57,7 +63,8 @@ Continuing education complete: transfer assessment passed; updated auth-boundary
 Before the controlled real-world preflight, the merged implementation has already passed:
 
 - canonical `message_agent` transport validation and real multi-turn teaching evidence;
-- native goal peer-wait verification with `NO CORE CHANGE` as the Phase 3 seam decision;
+- Phase 3 native goal peer-wait verification showing no additional wait scheduler/core loop was needed once a standing goal exists;
+- Phase 14 v3 proof that natural-language Bot learning did need a generic agent-to-GoalManager bridge, now provided by downstream Hermes `goal_manage`;
 - learner-only native skill-placement proof;
 - shared-skill packaging and byte-identity validation;
 - Dean routing tests, including ambiguous-keyword false-positive regressions;

--- a/docs/CONTINUING_EDUCATION_ARCHITECTURE.md
+++ b/docs/CONTINUING_EDUCATION_ARCHITECTURE.md
@@ -12,6 +12,21 @@ or any equivalent distributed-runtime system to exist, to be reachable, or
 to be installed. If any such system is present, Continuing Education must
 not depend on it.
 
+### Current pre-release Hermes compatibility
+
+The Phase 14 preflight proved one generic Hermes Bot Mode seam was missing: an
+agent could use `message_agent`, but could not programmatically establish the
+same native standing goal that a human reaches through `/goal`. The generic
+Bot-Chat-only `goal_manage` bridge is now merged in the maintained downstream
+Hermes Agent (`Dadmin88/hermes-agent-downstream` PR #24, merge `9b8de86a80`).
+It wraps the existing `GoalManager`/`GoalContract`; it does not add Academy
+state or a second goal loop.
+
+Until that generic bridge is present in the normal Hermes release used by a
+Profile Packs install, Continuing Education remains pre-release and must not be
+advertised as stock-install production ready. The hard invariant below remains
+the release requirement: no special Academy runtime may be required.
+
 ## Actors (exhaustive)
 
 Only these concepts exist. No other agent type, role, or persistence

--- a/hermes-academy/README.md
+++ b/hermes-academy/README.md
@@ -10,9 +10,9 @@ Academy v0.2 contains **30 faculty profiles and 120 purpose-built teaching skill
 
 ## Continuing Education
 
-Academy can also teach another installed Hermes profile through the Continuing Education flow. A learner can receive an ordinary request such as `Go learn API security`, route through `academy-dean` when needed, use native Hermes goal/Bot/learning primitives underneath, and persist a reusable capability in its own normal skill store.
+Academy can also teach another installed Hermes profile through the Continuing Education flow. A learner can receive an ordinary request such as `Go learn API security`, route through `academy-dean` when needed, use the Bot Chat `goal_manage` bridge into Hermes' native goal state plus `message_agent`/`/learn` underneath, and persist a reusable capability in its own normal skill store.
 
-The implementation is merged and validated through the Phase 10–13 quality gate, but the controlled persistent-capability preflight is still in progress. Treat this as **pre-release/experimental**, not yet production-validated. See [`../docs/CONTINUING_EDUCATION.md`](../docs/CONTINUING_EDUCATION.md) for current behavior and status.
+The implementation is merged and validated through the Phase 10–13 quality gate, but the controlled persistent-capability preflight is still in progress. Treat this as **pre-release/experimental**, not yet production-validated. The current preflight uses the generic `goal_manage` bridge merged in downstream Hermes PR #24; final stock-install readiness requires that capability in the normal Hermes release. See [`../docs/CONTINUING_EDUCATION.md`](../docs/CONTINUING_EDUCATION.md) for current behavior and status.
 
 Continuing Education is minimum-sufficient competency transfer, not a fixed classroom simulation. Instructors teach and assess; the learner owns `/learn` and all learner-local persistence. Canonical one-to-one transport is Bot Chat + `message_agent`, and there is no Fleet dependency.
 

--- a/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
+++ b/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-academy/tests/run_native_hermes_ce_checks.py
+++ b/hermes-academy/tests/run_native_hermes_ce_checks.py
@@ -38,6 +38,7 @@ NATIVE_TESTS = (
     "tests/gateway/test_goal_resume_restart.py::TestCliResumeRestartsWork",
     "tests/cli/test_cli_goal_interrupt.py",
     "tests/tools/test_bot_mode_dm.py",
+    "tests/tools/test_bot_mode_goal.py",
     "tests/agent/test_learn_prompt.py",
     "tests/tools/test_skill_manager_tool.py",
     "tests/tools/test_write_approval.py",
@@ -210,7 +211,7 @@ def main() -> int:
 
         result = {
             "hermes_source": str(source),
-            "native_pytest_cases": 144,
+            "native_pytest_cases": 159,
             "native_async_gateway_cases": 2,
             "profile_install": "PASS",
             "canonical_skill_sha256": canonical_hash,

--- a/hermes-academy/tests/test_ce_regression_matrix.py
+++ b/hermes-academy/tests/test_ce_regression_matrix.py
@@ -63,7 +63,8 @@ class ContinuingEducationRegressionMatrix(unittest.TestCase):
 
     def test_07_new_deficiency_becomes_native_subgoal(self):
         self.assertIn("new required deficiency", self.learner)
-        self.assertIn("native `/subgoal`", self.learner)
+        self.assertIn('goal_manage(action="add_subgoal"', self.learner)
+        self.assertIn("native `/goal` and `/subgoal` state", self.learner)
         self.assertIn("Do not create subgoals for routine corrections", self.learner)
 
     def test_08_transfer_pass_is_required_after_instruction(self):
@@ -99,8 +100,9 @@ class ContinuingEducationRegressionMatrix(unittest.TestCase):
         self.assertIn("update the active objective/criteria", self.learner)
 
     def test_14_goal_restart_state_is_not_reimplemented_in_profile_packs(self):
-        self.assertIn("actual native slash-command handlers", self.learner)
-        self.assertIn("never imitate their loop, persistence, approval, or completion logic", self.learner)
+        self.assertIn("Bot-Chat-only `goal_manage` bridge", self.learner)
+        self.assertIn("wraps Hermes' existing `GoalManager`", self.learner)
+        self.assertIn("never imitate its loop, persistence, approval, or completion logic", self.learner)
         self.assertNotIn("goal_state.json", self.learner)
 
     def test_15_bot_chat_resume_is_delegated_to_native_transport(self):

--- a/hermes-academy/tests/test_ce_security_adversarial.py
+++ b/hermes-academy/tests/test_ce_security_adversarial.py
@@ -336,7 +336,8 @@ class TestRecursiveTraining(unittest.TestCase):
         self.assertIn("Do not silently start another class", LEARNER_SKILL)
 
     def test_no_second_orchestration_loop(self):
-        self.assertIn("Do not create a second orchestration loop around `/goal` or `/subgoal`", LEARNER_SKILL)
+        self.assertIn("`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state", LEARNER_SKILL)
+        self.assertIn("Do not create a second orchestration loop around it", LEARNER_SKILL)
 
     def test_subgoal_only_for_new_required_deficiency(self):
         self.assertIn("new required deficiency", LEARNER_SKILL)

--- a/hermes-academy/tests/test_native_classroom_flow.py
+++ b/hermes-academy/tests/test_native_classroom_flow.py
@@ -16,10 +16,12 @@ class NativeGoalContractTests(unittest.TestCase):
         cls.instructor = INSTRUCTOR_SKILL.read_text(encoding="utf-8")
 
     def test_real_native_goal_and_subgoal_handlers_are_required(self):
-        self.assertIn("actual native `/goal` handler", self.learner)
-        self.assertIn("native `/subgoal`", self.learner)
-        self.assertIn("never imitate their loop, persistence, approval, or completion logic", self.learner)
-        self.assertIn("Do not create a second orchestration loop around `/goal` or `/subgoal`", self.learner)
+        self.assertIn('goal_manage(action="set"', self.learner)
+        self.assertIn('goal_manage(action="add_subgoal"', self.learner)
+        self.assertIn("native `/goal` and `/subgoal` state", self.learner)
+        self.assertIn("wraps Hermes' existing `GoalManager`", self.learner)
+        self.assertIn("never imitate its loop, persistence, approval, or completion logic", self.learner)
+        self.assertIn("Do not create a second orchestration loop around it", self.learner)
 
     def test_completion_contract_inputs_are_explicit(self):
         for marker in (

--- a/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 

--- a/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
@@ -12,7 +12,7 @@ Hermes Academy Continuing Education is a competency-transfer system, not a schoo
 
 - The current Hermes profile is the **Learner**. Keep its identity and normal profile state.
 - Every training event has one learner, one bounded objective, and one instructor. If no instructor is named, consult `academy-dean` and use the most specific available faculty member it recommends.
-- Use normal Hermes primitives only: native `/goal` and `/subgoal`, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. Invoke the actual native slash-command handlers; never imitate their loop, persistence, approval, or completion logic inside this skill.
+- Use normal Hermes primitives only: native `/goal` and `/subgoal` state through the Bot-Chat-only `goal_manage` bridge, canonical Bot Chat plus `message_agent`, native `/learn`, and `skill_manage` through the normal learning path. `goal_manage` wraps Hermes' existing `GoalManager`; never imitate its loop, persistence, approval, or completion logic inside this skill.
 - Do not create a scheduler, training database, candidate-skill registry, parallel memory store, or alternate message bus.
 - Do not depend on Fleet, Keryx, Nodescale, Templar, RunAuthority, or Run Capsules.
 - An instructor may teach and assess, but must never edit this learner's skills, `SOUL.md`, configuration, permissions, memory, or unrelated state.
@@ -31,7 +31,11 @@ If the user named an instructor, use it when it is appropriate for the objective
 
 ### 2. Establish the learner goal
 
-Internally invoke the actual native `/goal` handler for the learner-authoritative completion contract. The user should not have to know or type slash-command syntax. Derive the contract from:
+This flow must run in the learner's Bot-Mode-managed canonical `Bot Chat`, where native `goal_manage` and `message_agent` are available. If `goal_manage` is unavailable, stop and report that Continuing Education requires the learner's canonical Bot Chat on a compatible Hermes build. **Do not imitate `/goal`, create a replacement loop, or continue as a one-shot lesson.**
+
+Use `goal_manage(action="status")` to inspect the current session goal. If there is no active or paused goal, call `goal_manage(action="set", ...)` exactly once to create the learner-authoritative native goal. The user should not have to know or type slash-command syntax.
+
+Build the native goal text and `GoalContract` fields from:
 
 - this learner's profile/role;
 - the target competency;
@@ -42,11 +46,15 @@ Internally invoke the actual native `/goal` handler for the learner-authoritativ
 - the requirement to run `/learn` only if the event produced a reusable capability delta;
 - a stop condition for mastered, blocked, cancelled, budget-exhausted, or unavailable-instructor outcomes.
 
-If the instructor discovers a **new required deficiency** that is necessary to the active objective, attach it through native `/subgoal`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+Put the observable target in `goal`; put the required proof in `verification`; put safety/efficiency requirements in `constraints`; put learner/instructor authority limits in `boundaries`; and put honest terminal conditions in `stop_when`. Use Hermes' normal bounded goal budget.
 
-Use Hermes' normal bounded goal budget. If the budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+If a standing goal already exists, `goal_manage` will not replace it. Never work around that protection. Continue only when the existing goal already governs this requested education; otherwise tell the user that the standing goal must be changed or cleared before a new CE objective can begin.
 
-Do not create a second orchestration loop around `/goal` or `/subgoal`.
+If the instructor later discovers a **new required deficiency** that is necessary to the active objective, attach it with `goal_manage(action="add_subgoal", criterion="...")`. Do not create subgoals for routine corrections, optional enrichment, or adjacent topics.
+
+If the native goal budget is exhausted before the evidence contract is satisfied, pause and report: `Training paused because the learning objective has not yet been demonstrated.` Never convert budget exhaustion into success.
+
+`goal_manage` is only a bridge into Hermes' existing `/goal` and `/subgoal` state. Do not create a second orchestration loop around it.
 
 ### 3. Baseline before teaching
 


### PR DESCRIPTION
## Summary

Binds Hermes Academy Continuing Education to the generic Bot-Chat-only `goal_manage` bridge now merged in Hermes Agent downstream PR #24.

- natural-language CE requests establish the real current-session GoalManager state through `goal_manage(action="set", ...)`
- newly discovered required deficiencies attach through `goal_manage(action="add_subgoal")`
- refuses to imitate `/goal` when the bridge is unavailable
- refuses to replace an existing standing goal
- keeps user-facing slash/tool internals hidden
- keeps native peer-wait, `/learn`, `skill_manage`, write approval, and learner-skill preservation intact
- rematerializes the canonical learner skill into all participating Agency distributions
- updates public CE documentation and compatibility/status notes
- extends the permanent native Hermes test gate to include `tests/tools/test_bot_mode_goal.py`

## Validation

Against Hermes Agent downstream `9b8de86a80`:

- native Hermes selected suite: 159 PASS
- direct gateway async resume checks: 2 PASS
- disposable Backend Engineer install + canonical skill hash check: PASS
- Academy: 180 PASS
- Agency: 18 PASS
- Council: 3 PASS
- root: 16 PASS
- repository validator PASS
- `git diff --check` PASS

Phase 14 remains preflight-only until persistent capability improvement is proven in a fresh learner session.