### PR TITLE
fix(academy): load CE skill before Bot messaging

### DIFF
--- a/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
+++ b/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-academy/tests/test_continuing_education_skill.py
+++ b/hermes-academy/tests/test_continuing_education_skill.py
@@ -36,6 +36,10 @@ class ContinuingEducationSkillTests(unittest.TestCase):
         description = _frontmatter_value(self.text, "description")
         self.assertLessEqual(len(description), 60)
         self.assertTrue(description.endswith("."))
+        self.assertEqual(
+            description,
+            "MUST load first for Academy learning or go-learn requests.",
+        )
 
     def test_native_hermes_primitives_are_the_only_learning_path(self):
         for marker in ("`/goal`", "`message_agent`", "`/learn`", "`skill_manage`"):

--- a/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 

--- a/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academy-continuing-education
-description: Use when an Agency profile needs targeted Academy training.
+description: MUST load first for Academy learning or go-learn requests.
 ---
 # Academy Continuing Education
 


### PR DESCRIPTION
## Summary

Makes the canonical Continuing Education skill win routing before generic Bot Mode teammate messaging.

- changes the 58-character routing description to: `MUST load first for Academy learning or go-learn requests.`
- rematerializes the canonical bytes into all 109 Agency profiles
- adds a regression assertion for the exact routing description and 60-character budget

## Live proof

On a fresh disposable Backend Engineer with the exact natural-language request:

`Go learn API security from the Academy Cybersecurity Instructor.`

Tool order was:

1. `skill_view` for `academy-continuing-education`
2. `goal_manage(status)`
3. `goal_manage(set)`
4. learner baseline reasoning
5. `message_agent`

This fixes the previous behavior where generic Bot Mode instructions caused the learner to message the instructor without loading the CE contract or setting a native goal.

## Validation

- Academy: 180 PASS (1 opt-in native-runtime test skipped without HERMES_AGENT_SOURCE)
- Agency: 18 PASS
- repository validator PASS
- `git diff --check` PASS
