### PR TITLE
fix(academy): keep named instructor binding

### DIFF
--- a/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
+++ b/hermes-academy/shared-skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-academy/tests/test_ce_regression_matrix.py
+++ b/hermes-academy/tests/test_ce_regression_matrix.py
@@ -33,7 +33,8 @@ class ContinuingEducationRegressionMatrix(unittest.TestCase):
     # Phase 12 core cases -------------------------------------------------
     def test_01_user_names_instructor_directly(self):
         self.assertIn("If the user named an instructor", self.learner)
-        self.assertIn("use it when it is appropriate", self.learner)
+        self.assertIn("treat that choice as binding", self.learner)
+        self.assertIn("Do not silently substitute or message a different instructor", self.learner)
 
     def test_02_dean_routes_instructor(self):
         result = route_learner(

--- a/hermes-academy/tests/test_continuing_education_skill.py
+++ b/hermes-academy/tests/test_continuing_education_skill.py
@@ -74,6 +74,12 @@ class ContinuingEducationSkillTests(unittest.TestCase):
         self.assertIn("burn turns", self.text)
         self.assertIn("declare success while waiting", self.text)
 
+    def test_named_instructor_is_binding_and_fails_closed(self):
+        self.assertIn("treat that choice as binding", self.text)
+        self.assertIn("Do not silently substitute or message a different instructor", self.text)
+        self.assertIn("let the user choose whether to retry or select an alternative", self.text)
+        self.assertIn("Only when the user did **not** name an instructor", self.text)
+
     def test_authority_and_source_isolation_are_explicit(self):
         self.assertIn("must never edit this learner's skills", self.text)
         self.assertIn("Learning must remain local to this learner", self.text)

--- a/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-accessibility-reviewer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ai-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-analytics-specialist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-art-director/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-asset-artist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-audio-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-backend-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-brand-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-analyst/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-business-continuity-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-chief-of-staff/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-code-reviewer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-community-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-competitive-analyst/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-compliance-reviewer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-content-writer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-copywriter/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-creative-director/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-customer-success/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-data-scientist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-database-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-reviewer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-design-systems-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-desktop-application-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-developer-relations-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-devops-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-dialogue-writer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-distributed-systems-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-docs-writer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-editor-in-chief/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-email-marketer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-environment-artist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-finance-ops/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-frontend-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-fullstack-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-game-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-git-steward/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-godot-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-graphic-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-growth-marketer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-infrastructure-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-integration-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-knowledge-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-launch-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-legal-ops/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-level-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-localization-specialist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-lore-writer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-market-researcher/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-marketing-strategist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mlops-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-mobile-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-monetization-strategist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-motion-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-narrative-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-onboarding-specialist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-open-source-maintainer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-orchestrator/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-partnerships-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-people-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-performance-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-platform-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-privacy-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-procurement-specialist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-marketing-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-product-strategist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-program-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-project-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-public-relations/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-automation-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-lead/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-qa-tester/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-red-team/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-release-notes-writer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-requirements-analyst/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-research-analyst/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-revenue-operations-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scriptwriter/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-scrum-master/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-operations-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-security-reviewer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-seo-specialist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-service-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-site-reliability-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-social-media-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-software-architect/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-solutions-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-support-specialist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-systems-architect/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-artist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-lead/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-support-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-technical-writer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-tools-engineer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-traffic-manager/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-training-specialist/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-ui-ux-designer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-user-researcher/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-video-producer/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 

--- a/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
+++ b/hermes-agency/profiles/agency-worldbuilder/skills/academy-continuing-education/SKILL.md
@@ -27,7 +27,7 @@ Convert the user's request into one observable competency.
 
 Good objectives describe what the learner should be able to **do**, not a topic to "cover". Keep the scope narrow enough to assess in one bounded session.
 
-If the user named an instructor, use it when it is appropriate for the objective. Otherwise ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
+If the user named an instructor, treat that choice as binding when it is appropriate for the objective. Do not silently substitute or message a different instructor if the named instructor is unavailable; stop blocked, report the named instructor as unavailable, and let the user choose whether to retry or select an alternative. Only when the user did **not** name an instructor should you ask `academy-dean` for routing. Do not invent a faculty profile that is not installed.
 
 ### 2. Establish the learner goal
 


### PR DESCRIPTION
## Summary

When the user explicitly names an Academy instructor, that choice is now binding for the CE event.

- do not silently substitute or message another instructor if the named instructor is unavailable
- stop blocked and report the named instructor unavailable
- let the user choose whether to retry or select an alternative
- Dean routing remains the fallback only when the user did not name an instructor
- rematerialized to all 109 Agency profiles
- added focused regression coverage

This closes a Phase 14 finding where a broken Cybersecurity Instructor model caused the learner to briefly try Cloud Systems automatically.

## Validation

- Academy: 181 PASS (1 native-runtime opt-in skip without HERMES_AGENT_SOURCE)
- Agency: 18 PASS
- repository validator PASS
- git diff --check PASS
