### PR TITLE
Keep README profile counts synchronized

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ This repository is the public upstream home for reusable Hermes profile distribu
 
 The packs deliberately separate durable context domains. Agency executes professional work, Council supports the person, and Academy teaches. A work profile should not need private life context, a personal profile should not inherit repository state merely because both run on Hermes, and a teaching profile should not silently become a production executor.
 
-Hermes Council currently contains 21 focused profiles and 84 purpose-built personal-life skills. Hermes Academy v0.2 contains 30 faculty profiles and 120 purpose-built teaching skills. Hermes Agency contains 110 professional specialists.
+<!-- profile-counts:start -->
+Hermes Agency contains 110 professional specialists. Hermes Council contains 21 focused profiles and 84 purpose-built personal-life skills. Hermes Academy contains 30 faculty profiles and 120 purpose-built teaching skills.
+<!-- profile-counts:end -->
 
 ### Academy Continuing Education
 
@@ -58,6 +60,8 @@ hermes-profile-packs/
 │   └── CONTINUING_EDUCATION_RELEASE_REVIEW.md
 ├── examples/
 ├── tests/
+├── scripts/
+│   └── update_readme_counts.py # Regenerates README profile and skill counts
 ├── packs.json
 ├── recipes.json
 ├── recipe_catalog.py       # Shared recipe loading/scoring/confidence engine
@@ -117,10 +121,13 @@ Use [`docs/OPERATING_PLAYBOOK.md`](docs/OPERATING_PLAYBOOK.md), [`docs/INSTALLAT
 
 ```bash
 python validate.py
+python scripts/update_readme_counts.py --check
 python -m unittest discover -s tests -p 'test_*.py'
 ```
 
-This validates pack manifests, namespaces, distribution metadata, skills, portability, secret/path hygiene, team recipe references/tier invariants, and root selector behavior.
+`validate.py` also checks that the generated README profile and skill counts match the pack manifests. After adding or removing a profile or skill, run `python scripts/update_readme_counts.py` to refresh the README. GitHub README files cannot run inline JavaScript, so the committed Markdown is generated and CI-enforced instead.
+
+The validation suite checks pack manifests, namespaces, distribution metadata, skills, portability, secret/path hygiene, team recipe references/tier invariants, generated documentation counts, and root selector behavior.
 
 ## Design principles
 

--- a/scripts/update_readme_counts.py
+++ b/scripts/update_readme_counts.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+START_MARKER = "<!-- profile-counts:start -->"
+END_MARKER = "<!-- profile-counts:end -->"
+TOTAL_PATTERN = re.compile(r"You rarely need all \d+ profiles\.")
+
+
+@dataclass(frozen=True)
+class PackCounts:
+    profiles: int
+    skills: int
+
+
+def plural(count: int, singular: str, plural_form: str | None = None) -> str:
+    noun = singular if count == 1 else (plural_form or f"{singular}s")
+    return f"{count} {noun}"
+
+
+def load_counts(root: Path) -> dict[str, PackCounts]:
+    registry = json.loads((root / "packs.json").read_text(encoding="utf-8"))
+    counts: dict[str, PackCounts] = {}
+    for pack in registry["packs"]:
+        pack_dir = root / pack["path"]
+        key = pack_dir.name.removeprefix("hermes-")
+        manifest = json.loads((root / pack["manifest"]).read_text(encoding="utf-8"))
+        profiles = manifest.get("profiles", [])
+        profile_count = len(profiles)
+        skill_count = sum(len(profile.get("jobs", [])) for profile in profiles)
+        counts[key] = PackCounts(profile_count, skill_count)
+    return counts
+
+
+def generated_summary(counts: dict[str, PackCounts]) -> str:
+    agency = counts["agency"]
+    council = counts["council"]
+    academy = counts["academy"]
+    return "\n".join(
+        [
+            START_MARKER,
+            f"Hermes Agency contains {plural(agency.profiles, 'professional specialist')}. "
+            f"Hermes Council contains {plural(council.profiles, 'focused profile')} and "
+            f"{plural(council.skills, 'purpose-built personal-life skill')}. "
+            f"Hermes Academy contains {plural(academy.profiles, 'faculty profile')} and "
+            f"{plural(academy.skills, 'purpose-built teaching skill')}.",
+            END_MARKER,
+        ]
+    )
+
+
+def update_readme(root: Path, check: bool = False) -> bool:
+    readme_path = root / "README.md"
+    original = readme_path.read_text(encoding="utf-8")
+    if original.count(START_MARKER) != 1 or original.count(END_MARKER) != 1:
+        raise ValueError("README.md must contain exactly one profile-count marker pair")
+
+    start = original.index(START_MARKER)
+    end = original.index(END_MARKER, start) + len(END_MARKER)
+    counts = load_counts(root)
+    updated = original[:start] + generated_summary(counts) + original[end:]
+
+    total = sum(pack.profiles for pack in counts.values())
+    updated, replacements = TOTAL_PATTERN.subn(
+        f"You rarely need all {total} profiles.", updated, count=1
+    )
+    if replacements != 1:
+        raise ValueError("README.md must contain one 'You rarely need all N profiles.' sentence")
+
+    if updated == original:
+        return False
+    if check:
+        return True
+    readme_path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Update generated profile and skill counts in README.md."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root (defaults to this script's parent repository).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit with status 1 instead of writing when README.md is stale.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        changed = update_readme(args.root.resolve(), check=args.check)
+    except (KeyError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"README count update failed: {exc}", file=sys.stderr)
+        return 2
+
+    if args.check and changed:
+        print(
+            "README profile counts are stale. Run: python scripts/update_readme_counts.py",
+            file=sys.stderr,
+        )
+        return 1
+    if changed:
+        print("Updated README profile counts.")
+    else:
+        print("README profile counts are current.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_update_readme_counts.py
+++ b/tests/test_update_readme_counts.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "update_readme_counts.py"
+
+
+class ReadmeCountUpdaterTests(unittest.TestCase):
+    def make_repo(self, root: Path) -> None:
+        packs = {
+            "packs": [
+                {"path": "hermes-agency", "manifest": "hermes-agency/agency.json"},
+                {"path": "hermes-council", "manifest": "hermes-council/council.json"},
+                {"path": "hermes-academy", "manifest": "hermes-academy/academy.json"},
+            ]
+        }
+        (root / "packs.json").write_text(json.dumps(packs), encoding="utf-8")
+
+        fixtures = {"agency": (2, 0), "council": (1, 2), "academy": (3, 4)}
+        for pack, (profile_count, skill_count) in fixtures.items():
+            pack_dir = root / f"hermes-{pack}"
+            profiles_dir = pack_dir / "profiles"
+            profiles_dir.mkdir(parents=True)
+            profiles = []
+            for profile_index in range(profile_count):
+                name = f"{pack}-profile-{profile_index}"
+                declared_skills = [
+                    f"skill-{skill_index}"
+                    for skill_index in range(skill_count if profile_index == 0 else 0)
+                ]
+                profiles.append({"name": name, "jobs": declared_skills})
+                profile_dir = profiles_dir / name
+                profile_dir.mkdir()
+                for skill_name in declared_skills:
+                    skill_dir = profile_dir / "skills" / skill_name
+                    skill_dir.mkdir(parents=True)
+                    (skill_dir / "SKILL.md").write_text("# Test skill\n", encoding="utf-8")
+            if pack == "academy":
+                shared = profiles_dir / "academy-profile-1" / "skills" / "materialized-shared"
+                shared.mkdir(parents=True)
+                (shared / "SKILL.md").write_text("# Shared skill\n", encoding="utf-8")
+            (pack_dir / f"{pack}.json").write_text(
+                json.dumps({"profiles": profiles}), encoding="utf-8"
+            )
+
+        (root / "README.md").write_text(
+            "# Test\n\n"
+            "<!-- profile-counts:start -->\n"
+            "stale summary\n"
+            "<!-- profile-counts:end -->\n\n"
+            "You rarely need all 999 profiles.\n",
+            encoding="utf-8",
+        )
+
+    def run_script(self, root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(root), *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_updates_generated_counts_and_total(self):
+        self.assertTrue(SCRIPT.is_file(), "README count updater script is missing")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_repo(root)
+            result = self.run_script(root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            readme = (root / "README.md").read_text(encoding="utf-8")
+            self.assertIn("Hermes Agency contains 2 professional specialists.", readme)
+            self.assertIn("Hermes Council contains 1 focused profile and 2 purpose-built personal-life skills.", readme)
+            self.assertIn("Hermes Academy contains 3 faculty profiles and 4 purpose-built teaching skills.", readme)
+            self.assertIn("You rarely need all 6 profiles.", readme)
+
+    def test_check_mode_detects_stale_readme_without_writing(self):
+        self.assertTrue(SCRIPT.is_file(), "README count updater script is missing")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_repo(root)
+            before = (root / "README.md").read_text(encoding="utf-8")
+            stale = self.run_script(root, "--check")
+            self.assertEqual(stale.returncode, 1)
+            self.assertEqual((root / "README.md").read_text(encoding="utf-8"), before)
+            self.assertIn("python scripts/update_readme_counts.py", stale.stderr)
+            self.assertEqual(self.run_script(root).returncode, 0)
+            current = self.run_script(root, "--check")
+            self.assertEqual(current.returncode, 0, current.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validate.py
+++ b/validate.py
@@ -124,6 +124,13 @@ def main() -> int:
 
     errors.extend(validate_recipes(profile_to_pack, pack_keys))
 
+    readme_count_check = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "update_readme_counts.py"), "--check"],
+        cwd=ROOT,
+    )
+    if readme_count_check.returncode:
+        errors.append("README profile counts are stale or could not be verified")
+
     for path in ROOT.rglob("*"):
         if not path.is_file() or ".git" in path.parts or "__pycache__" in path.parts or path.suffix == ".pyc":
             continue


### PR DESCRIPTION
## Summary
- generate per-pack profile and skill counts from the pack manifests
- update the README's total profile count from the same source
- fail repository validation when generated counts are stale
- document why GitHub README files cannot use inline JavaScript and how to refresh the generated section

## Verification
- OK: 110 profiles, 715 bundled skills, 5 sourced skills, 85 routing evals
Hermes Council validation passed: 21 profiles, 84 skills
Hermes Academy validation passed: 30 profiles, 120 skills, 2 shared skills
README profile counts are current.
Repository validation passed.
- 
- 
- 
- 
- independent review passed with no security concerns or logic errors